### PR TITLE
Fix duplicate RegistrationForm definition

### DIFF
--- a/WebAppIAM/core/forms.py
+++ b/WebAppIAM/core/forms.py
@@ -1,12 +1,6 @@
 from django import forms
-from django.contrib.auth.forms import UserCreationForm, PasswordChangeForm
+from django.contrib.auth.forms import PasswordChangeForm
 from .models import User, RiskPolicy, Document, UserProfile
-
-class RegistrationForm(UserCreationForm):
-    role = forms.ChoiceField(choices=[('USER', 'User'), ('ADMIN', 'Admin')], initial='USER')
-    class Meta:
-        model = User
-        fields = ('username', 'role', 'password1', 'password2')
 
 class RegistrationForm(forms.ModelForm):
     password1 = forms.CharField(


### PR DESCRIPTION
## Summary
- remove the unused `RegistrationForm` subclass from `forms.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880991053a88320be46499e6cae7c97