### PR TITLE
Add NeumorphicAuth authentication templates

### DIFF
--- a/WebAppIAM/core/static/css/styles.css
+++ b/WebAppIAM/core/static/css/styles.css
@@ -1,0 +1,79 @@
+/* NeumorphicAuth shared styles */
+body {
+    background: #e0e5ec;
+    font-family: Arial, sans-serif;
+    color: #333;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+}
+.auth-container {
+    width: 100%;
+    max-width: 420px;
+    padding: 1.5rem;
+}
+.auth-card {
+    background: #e0e5ec;
+    border-radius: 10px;
+    box-shadow: 7px 7px 15px #babecc, -7px -7px 15px #fff;
+    padding: 2rem;
+}
+.auth-card h2 {
+    margin-top: 0;
+    text-align: center;
+    margin-bottom: 1.5rem;
+}
+.form-group {
+    margin-bottom: 1rem;
+}
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="file"],
+select,
+textarea {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: none;
+    border-radius: 8px;
+    background: #e0e5ec;
+    box-shadow: inset 6px 6px 12px #babecc, inset -6px -6px 12px #fff;
+    font-size: 1rem;
+}
+input:focus, select:focus, textarea:focus {
+    outline: none;
+    box-shadow: inset 4px 4px 8px #babecc, inset -4px -4px 8px #fff;
+}
+.btn-primary, .btn-secondary {
+    display: inline-block;
+    padding: 0.6rem 1.2rem;
+    margin-top: 0.5rem;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    width: 100%;
+}
+.btn-primary {
+    background: #e0e5ec;
+    box-shadow: 6px 6px 12px #babecc, -6px -6px 12px #fff;
+}
+.btn-primary:active {
+    box-shadow: inset 6px 6px 12px #babecc, inset -6px -6px 12px #fff;
+}
+.btn-secondary {
+    background: #d1d9e6;
+    box-shadow: 6px 6px 12px #babecc, -6px -6px 12px #fff;
+}
+.alert {
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+}
+.alert.error { background: #ffdddd; }
+.alert.success { background: #ddffdd; }
+.alert.info { background: #ddeeff; }
+.text-small { font-size: 0.9rem; text-align: center; }
+.hidden { display: none; }

--- a/WebAppIAM/core/static/js/auth.js
+++ b/WebAppIAM/core/static/js/auth.js
@@ -1,0 +1,137 @@
+// Shared authentication logic for NeumorphicAuth
+const keystrokeEvents = [];
+let lastKeyTime = null;
+
+function recordKeystroke(event) {
+    const now = Date.now();
+    if (lastKeyTime === null) lastKeyTime = now;
+    keystrokeEvents.push({key: event.key, type: event.type, time: now, delta: now - lastKeyTime});
+    lastKeyTime = now;
+}
+
+function attachKeystrokeListeners(form) {
+    const username = form.querySelector('input[name="username"], input[name="email"]');
+    const password = form.querySelector('input[type="password"]');
+    if (username) {
+        username.addEventListener('keydown', recordKeystroke);
+        username.addEventListener('keyup', recordKeystroke);
+    }
+    if (password) {
+        password.addEventListener('keydown', recordKeystroke);
+        password.addEventListener('keyup', recordKeystroke);
+    }
+    form.addEventListener('submit', () => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'keystroke_data';
+        input.value = JSON.stringify(keystrokeEvents);
+        form.appendChild(input);
+    });
+}
+
+function validatePasswords(form) {
+    const p1 = form.querySelector('input[name="password1"]');
+    const p2 = form.querySelector('input[name="password2"]');
+    if (!p1 || !p2) return;
+    function check() {
+        if (p1.value !== p2.value) {
+            p2.setCustomValidity('Passwords do not match');
+        } else {
+            p2.setCustomValidity('');
+        }
+    }
+    p1.addEventListener('input', check);
+    p2.addEventListener('input', check);
+}
+
+function checkAvailability(input, url) {
+    input.addEventListener('blur', () => {
+        fetch(url + '?value=' + encodeURIComponent(input.value))
+            .then(r => r.json())
+            .then(data => {
+                if (!data.available) {
+                    input.setCustomValidity('Not available');
+                } else {
+                    input.setCustomValidity('');
+                }
+            })
+            .catch(() => {});
+    });
+}
+
+function initWebAuthn(optionsUrl, verifyUrl) {
+    const btn = document.getElementById('webauthnBtn');
+    if (!btn || !window.PublicKeyCredential) return;
+    btn.addEventListener('click', () => {
+        fetch(optionsUrl, {headers: {'X-CSRFToken': getCSRFToken()}})
+            .then(r => r.json())
+            .then(async options => {
+                options.challenge = Uint8Array.from(atob(options.challenge), c => c.charCodeAt(0));
+                options.user.id = Uint8Array.from(atob(options.user.id), c => c.charCodeAt(0));
+                const cred = await navigator.credentials.create({publicKey: options});
+                const data = {
+                    id: cred.id,
+                    rawId: btoa(String.fromCharCode.apply(null, new Uint8Array(cred.rawId))),
+                    type: cred.type,
+                    response: {
+                        clientDataJSON: btoa(String.fromCharCode.apply(null, new Uint8Array(cred.response.clientDataJSON))),
+                        attestationObject: btoa(String.fromCharCode.apply(null, new Uint8Array(cred.response.attestationObject)))
+                    }
+                };
+                return fetch(verifyUrl, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json', 'X-CSRFToken': getCSRFToken()},
+                    body: JSON.stringify(data)
+                });
+            })
+            .then(r => r.json())
+            .then(res => {
+                if (res.status === 'success' && res.redirect) {
+                    window.location.href = res.redirect;
+                }
+            })
+            .catch(console.error);
+    });
+}
+
+function initFaceCapture() {
+    const video = document.getElementById('faceVideo');
+    const canvas = document.getElementById('faceCanvas');
+    const captureBtn = document.getElementById('captureFace');
+    const form = document.getElementById('faceForm');
+    if (!video || !canvas || !captureBtn) return;
+    navigator.mediaDevices.getUserMedia({video: true}).then(stream => {
+        video.srcObject = stream;
+    });
+    captureBtn.addEventListener('click', () => {
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        canvas.getContext('2d').drawImage(video, 0, 0);
+        canvas.toBlob(blob => {
+            const file = new File([blob], 'face.png', {type: 'image/png'});
+            const data = new FormData(form);
+            data.set('face_data', file);
+            fetch(form.action, {method: 'POST', headers: {'X-CSRFToken': getCSRFToken()}, body: data})
+                .then(r => r.json())
+                .then(res => { if(res.status === 'success' && res.redirect){ window.location.href = res.redirect; }});
+        });
+    });
+}
+
+function getCSRFToken() {
+    const cookieValue = document.cookie.split('; ').find(row => row.startsWith('csrftoken='));
+    return cookieValue ? cookieValue.split('=')[1] : '';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('form[data-auth]').forEach(form => {
+        attachKeystrokeListeners(form);
+        validatePasswords(form);
+    });
+    const username = document.querySelector('#id_username');
+    if (username) checkAvailability(username, '/api/validate-username/');
+    const email = document.querySelector('#id_email');
+    if (email) checkAvailability(email, '/api/validate-email/');
+    initWebAuthn('/register/webauthn/options/', '/register/webauthn/verify/');
+    initFaceCapture();
+});

--- a/WebAppIAM/core/templates/core/access_denied.html
+++ b/WebAppIAM/core/templates/core/access_denied.html
@@ -1,15 +1,19 @@
-<!-- Access Denied Template -->
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Access Denied - Web App IAM</title>
-    <link rel="stylesheet" href="{% static 'css/security.css' %}">
+    <title>Access Denied - NeumorphicAuth</title>
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body>
-    <!-- Access denied message will be added here -->
-    <script src="{% static 'js/security.js' %}"></script>
+<main class="auth-container">
+    <div class="auth-card">
+        <h2>Access Restricted</h2>
+        <p>{{ reason }}</p>
+        <a href="{% url 'core:login' %}" class="btn-primary">Return to login</a>
+    </div>
+</main>
 </body>
 </html>

--- a/WebAppIAM/core/templates/core/emergency_access.html
+++ b/WebAppIAM/core/templates/core/emergency_access.html
@@ -1,109 +1,55 @@
-{% extends 'core/base.html' %}
-
-{% block title %}Emergency Access Protocol{% endblock %}
-
-{% block content %}
-<div class="container mt-5">
-    <div class="row">
-        <div class="col-md-12">
-            <div class="card border-danger mb-4">
-                <div class="card-header bg-danger text-white">
-                    <h4><i class="fas fa-exclamation-triangle"></i> Emergency Access Protocol</h4>
-                </div>
-                <div class="card-body">
-                    <div class="alert alert-warning">
-                        <strong>Warning:</strong> This page provides emergency access functionality that bypasses normal security protocols. Use only in critical situations.
-                    </div>
-
-                    <h5 class="card-title">Current Status</h5>
-                    <div class="d-flex align-items-center mb-4">
-                        <div class="status-indicator {% if emergency_mode %}bg-danger{% else %}bg-success{% endif %} mr-3"></div>
-                        <div>
-                            <strong>Emergency Mode:</strong>
-                            {% if emergency_mode %}
-                                <span class="badge bg-danger">ACTIVE</span>
-                            {% else %}
-                                <span class="badge bg-success">INACTIVE</span>
-                            {% endif %}
-                        </div>
-                    </div>
-
-                    {% if emergency_mode %}
-                    <div class="alert alert-danger">
-                        <h5><i class="fas fa-exclamation-circle"></i> Emergency mode is currently ACTIVE</h5>
-                        <p>Security protocols are in a reduced state. This should be deactivated as soon as the emergency situation is resolved.</p>
-                    </div>
-                    <form method="POST" action="{% url 'deactivate_emergency' %}" class="mb-4">
-                        {% csrf_token %}
-                        <div class="mb-3">
-                            <label for="deactivate_reason" class="form-label">Reason for deactivation:</label>
-                            <textarea class="form-control" name="reason" id="deactivate_reason" rows="2" required></textarea>
-                        </div>
-                        <button type="submit" class="btn btn-success">
-                            <i class="fas fa-shield-alt"></i> Deactivate Emergency Mode
-                        </button>
-                    </form>
-                    {% else %}
-                    <form method="POST" action="{% url 'activate_emergency' %}" class="mb-4">
-                        {% csrf_token %}
-                        <div class="mb-3">
-                            <label for="activate_reason" class="form-label">Reason for activation:</label>
-                            <textarea class="form-control" name="reason" id="activate_reason" rows="2" required></textarea>
-                        </div>
-                        <button type="submit" class="btn btn-danger">
-                            <i class="fas fa-exclamation-circle"></i> Activate Emergency Mode
-                        </button>
-                    </form>
-                    {% endif %}
-
-                    <hr class="my-4">
-
-                    <h5 class="card-title">Generate Emergency Access Token</h5>
-                    <p>Generate a one-time emergency access token for a user who needs to bypass normal authentication.</p>
-                    <form method="POST" action="{% url 'generate_emergency_token' %}">
-                        {% csrf_token %}
-                        <div class="mb-3">
-                            <label for="username" class="form-label">Username:</label>
-                            <input type="text" class="form-control" name="username" id="username" required>
-                        </div>
-                        <div class="mb-3">
-                            <label for="token_reason" class="form-label">Reason:</label>
-                            <textarea class="form-control" name="reason" id="token_reason" rows="2" required></textarea>
-                        </div>
-                        <button type="submit" class="btn btn-primary">
-                            <i class="fas fa-key"></i> Generate Token
-                        </button>
-                    </form>
-
-                    {% if emergency_token %}
-                    <div class="alert alert-info mt-4">
-                        <h5>Emergency Token Generated</h5>
-                        <p>The emergency access token for {{ token_username }} is:</p>
-                        <div class="p-3 bg-light border rounded">
-                            <code class="token-display">{{ emergency_token }}</code>
-                        </div>
-                        <p class="mt-2"><strong>Important:</strong> This token will be valid for 4 hours and can only be used once. Please share it securely with the user.</p>
-                    </div>
-                    {% endif %}
-                </div>
-                <div class="card-footer">
-                    <small class="text-muted">All emergency access actions are logged and monitored.</small>
-                </div>
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Emergency Access Dashboard - NeumorphicAuth</title>
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+</head>
+<body>
+<main class="auth-container">
+    <div class="auth-card">
+        <h2>Emergency Access Protocol</h2>
+        <div class="alert info">Use only in critical situations. All actions are logged.</div>
+        {% if emergency_mode %}
+        <div class="alert error">Emergency mode is currently ACTIVE.</div>
+        <form method="post" action="{% url 'deactivate_emergency' %}">
+            {% csrf_token %}
+            <div class="form-group"><label for="deactivate_reason">Reason for deactivation</label>
+                <textarea id="deactivate_reason" name="reason" required></textarea>
             </div>
+            <button class="btn-secondary" type="submit">Deactivate Emergency Mode</button>
+        </form>
+        {% else %}
+        <form method="post" action="{% url 'activate_emergency' %}">
+            {% csrf_token %}
+            <div class="form-group"><label for="activate_reason">Reason for activation</label>
+                <textarea id="activate_reason" name="reason" required></textarea>
+            </div>
+            <button class="btn-primary" type="submit">Activate Emergency Mode</button>
+        </form>
+        {% endif %}
+        <hr>
+        <h3>Generate Emergency Token</h3>
+        <form method="post" action="{% url 'generate_emergency_token' %}">
+            {% csrf_token %}
+            <div class="form-group"><label for="username">Username</label>
+                <input type="text" id="username" name="username" required>
+            </div>
+            <div class="form-group"><label for="token_reason">Reason</label>
+                <textarea id="token_reason" name="reason" required></textarea>
+            </div>
+            <button class="btn-primary" type="submit">Generate Token</button>
+        </form>
+        {% if emergency_token %}
+        <div class="alert info">
+            Emergency token for {{ token_username }}:<br>
+            <strong>{{ emergency_token }}</strong>
         </div>
+        {% endif %}
     </div>
-</div>
-
-<style>
-    .status-indicator {
-        width: 15px;
-        height: 15px;
-        border-radius: 50%;
-        margin-right: 10px;
-    }
-    .token-display {
-        font-size: 1.2rem;
-        word-break: break-all;
-    }
-</style>
-{% endblock %}
+</main>
+<script src="{% static 'js/auth.js' %}"></script>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/emergency_login.html
+++ b/WebAppIAM/core/templates/core/emergency_login.html
@@ -1,50 +1,31 @@
-{% extends 'core/base.html' %}
-
-{% block title %}Emergency Access{% endblock %}
-
-{% block content %}
-<div class="container mt-5">
-    <div class="row justify-content-center">
-        <div class="col-md-6">
-            <div class="card border-warning">
-                <div class="card-header bg-warning text-dark">
-                    <h4><i class="fas fa-key"></i> Emergency Access</h4>
-                </div>
-                <div class="card-body">
-                    <div class="alert alert-info">
-                        <p>If you have been issued an emergency access token, enter it below to access your account.</p>
-                    </div>
-
-                    {% if error_message %}
-                    <div class="alert alert-danger">
-                        <p>{{ error_message }}</p>
-                    </div>
-                    {% endif %}
-
-                    <form method="POST" action="{% url 'emergency_login' %}">
-                        {% csrf_token %}
-                        <div class="mb-3">
-                            <label for="username" class="form-label">Username:</label>
-                            <input type="text" class="form-control" name="username" id="username" required>
-                        </div>
-                        <div class="mb-3">
-                            <label for="emergency_token" class="form-label">Emergency Access Token:</label>
-                            <input type="text" class="form-control" name="emergency_token" id="emergency_token" required>
-                        </div>
-                        <button type="submit" class="btn btn-warning w-100">
-                            <i class="fas fa-sign-in-alt"></i> Access Account
-                        </button>
-                    </form>
-
-                    <div class="mt-3 text-center">
-                        <a href="{% url 'login' %}" class="text-decoration-none">Return to normal login</a>
-                    </div>
-                </div>
-                <div class="card-footer">
-                    <small class="text-muted">All emergency access attempts are logged and monitored.</small>
-                </div>
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Emergency Access - NeumorphicAuth</title>
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+</head>
+<body>
+<main class="auth-container">
+    <div class="auth-card">
+        <h2>Emergency Access</h2>
+        <p>If you have an emergency token, enter it below.</p>
+        {% if error_message %}<div class="alert error" role="alert">{{ error_message }}</div>{% endif %}
+        <form method="post" action="{% url 'emergency_login' %}" data-auth>
+            {% csrf_token %}
+            <div class="form-group"> <label for="username">Username</label>
+                <input type="text" name="username" id="username" required autofocus>
             </div>
-        </div>
+            <div class="form-group"> <label for="emergency_token">Emergency Token</label>
+                <input type="text" name="emergency_token" id="emergency_token" required>
+            </div>
+            <button class="btn-primary" type="submit">Access Account</button>
+        </form>
+        <p class="text-small"><a href="{% url 'core:login' %}">Return to normal login</a></p>
     </div>
-</div>
-{% endblock %}
+</main>
+<script src="{% static 'js/auth.js' %}"></script>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/login.html
+++ b/WebAppIAM/core/templates/core/login.html
@@ -1,59 +1,44 @@
-{% extends 'core/base.html' %}
-
-{% block title %}Login{% endblock %}
-
-{% block content %}
-<div class="container mt-5">
-    <div class="row justify-content-center">
-        <div class="col-md-6">
-            <div class="card shadow">
-                <div class="card-header bg-primary text-white">
-                    <h4><i class="fas fa-sign-in-alt"></i> Login</h4>
-                </div>
-                <div class="card-body">
-                    {% if error_message %}
-                    <div class="alert alert-danger">
-                        {{ error_message }}
-                    </div>
-                    {% endif %}
-
-                    {% if messages %}
-                    {% for message in messages %}
-                    <div class="alert alert-{{ message.tags }}">
-                        {{ message }}
-                    </div>
-                    {% endfor %}
-                    {% endif %}
-
-                    <form method="POST" action="{% url 'core:login' %}">
-                        {% csrf_token %}
-                        <div class="mb-3">
-                            <label for="username" class="form-label">Username</label>
-                            <input type="text" class="form-control" id="username" name="username" required>
-                        </div>
-                        <div class="mb-3">
-                            <label for="password" class="form-label">Password</label>
-                            <input type="password" class="form-control" id="password" name="password" required>
-                        </div>
-                        <button type="submit" class="btn btn-primary w-100">Login</button>
-                    </form>
-
-                    <div class="mt-3 text-center">
-                        <a href="{% url 'core:password_reset' %}">Forgot Password?</a>
-                        <div class="mt-2">
-                            Don't have an account? <a href="{% url 'core:register' %}">Register here</a>
-                        </div>
-                        <hr class="my-3">
-                        <div>
-                            <a href="{% url 'core:emergency_login_page' %}" class="text-danger">
-                                <i class="fas fa-exclamation-triangle"></i> Emergency Access
-                            </a>
-                        </div>
-                    </div>
-                </div>
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - NeumorphicAuth</title>
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+</head>
+<body>
+<main class="auth-container">
+    <div class="auth-card" role="form">
+        <h2>Login</h2>
+        {% if messages %}
+            {% for message in messages %}
+                <div class="alert {{ message.tags }}" role="alert">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+        {% if error_message %}<div class="alert error" role="alert">{{ error_message }}</div>{% endif %}
+        <form method="post" action="{% url 'core:login' %}" data-auth>
+            {% csrf_token %}
+            {{ form.non_field_errors }}
+            <div class="form-group">
+                {{ form.username.label_tag }}
+                {{ form.username|addattr:"autofocus" }}
             </div>
-        </div>
+            <div class="form-group">
+                {{ form.password.label_tag }}
+                {{ form.password }}
+            </div>
+            <button class="btn-primary" type="submit">Sign in</button>
+        </form>
+        <p class="text-small"><a href="{% url 'core:password_reset' %}">Forgot password?</a></p>
+        {% if show_biometric_verification %}
+        <form method="post" action="{% url 'core:verify_biometrics' %}">
+            {% csrf_token %}
+            <button type="submit" class="btn-secondary">Verify with biometrics</button>
+        </form>
+        {% endif %}
     </div>
-</div>
-<script src="{% static 'js/authentication.js' %}"></script>
-{% endblock %}
+</main>
+<script src="{% static 'js/auth.js' %}"></script>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/password_reset.html
+++ b/WebAppIAM/core/templates/core/password_reset.html
@@ -1,15 +1,27 @@
-<!-- Password Reset Template -->
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Password Reset - Web App IAM</title>
-    <link rel="stylesheet" href="{% static 'css/authentication.css' %}">
+    <title>Password Reset - NeumorphicAuth</title>
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body>
-    <!-- Password reset form will be added here -->
-    <script src="{% static 'js/authentication.js' %}"></script>
+<main class="auth-container">
+    <div class="auth-card">
+        <h2>Password Reset</h2>
+        <form method="post" action="{% url 'core:password_reset' %}" data-auth>
+            {% csrf_token %}
+            {{ form.non_field_errors }}
+            <div class="form-group">
+                {{ form.email.label_tag }}
+                {{ form.email|addattr:"autofocus" }}
+            </div>
+            <button type="submit" class="btn-primary">Send reset link</button>
+        </form>
+    </div>
+</main>
+<script src="{% static 'js/auth.js' %}"></script>
 </body>
 </html>

--- a/WebAppIAM/core/templates/core/password_reset_complete.html
+++ b/WebAppIAM/core/templates/core/password_reset_complete.html
@@ -4,15 +4,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Reset Sent - NeumorphicAuth</title>
+    <title>Password Changed - NeumorphicAuth</title>
     <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body>
 <main class="auth-container">
     <div class="auth-card">
-        <h2>Check your inbox</h2>
-        <p>We've emailed you instructions for resetting your password.</p>
-        <a href="{% url 'core:login' %}" class="btn-primary">Return to login</a>
+        <h2>Password Updated</h2>
+        <p>Your password has been successfully changed.</p>
+        <a href="{% url 'core:login' %}" class="btn-primary">Sign in</a>
     </div>
 </main>
 </body>

--- a/WebAppIAM/core/templates/core/password_reset_confirm.html
+++ b/WebAppIAM/core/templates/core/password_reset_confirm.html
@@ -1,15 +1,25 @@
-<!-- Password Reset Confirmation Template -->
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Password Reset Confirmation - Web App IAM</title>
-    <link rel="stylesheet" href="{% static 'css/authentication.css' %}">
+    <title>Set New Password - NeumorphicAuth</title>
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body>
-    <!-- Password reset confirmation form will be added here -->
-    <script src="{% static 'js/authentication.js' %}"></script>
+<main class="auth-container">
+    <div class="auth-card">
+        <h2>Set New Password</h2>
+        <form method="post" data-auth>
+            {% csrf_token %}
+            {{ form.non_field_errors }}
+            <div class="form-group">{{ form.password1.label_tag }}{{ form.password1|addattr:"autofocus" }}</div>
+            <div class="form-group">{{ form.password2.label_tag }}{{ form.password2 }}</div>
+            <button class="btn-primary" type="submit">Change password</button>
+        </form>
+    </div>
+</main>
+<script src="{% static 'js/auth.js' %}"></script>
 </body>
 </html>

--- a/WebAppIAM/core/templates/core/register.html
+++ b/WebAppIAM/core/templates/core/register.html
@@ -1,0 +1,59 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Register - NeumorphicAuth</title>
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+</head>
+<body>
+<main class="auth-container">
+    <div class="auth-card">
+        {% if show_profile_completion %}
+            <h2>Complete Profile</h2>
+            <form method="post" action="{% url 'core:complete_profile' %}" data-auth>
+                {% csrf_token %}
+                {{ form.non_field_errors }}
+                <div class="form-group">{{ form.first_name.label_tag }}{{ form.first_name|addattr:"autofocus" }}</div>
+                <div class="form-group">{{ form.last_name.label_tag }}{{ form.last_name }}</div>
+                <div class="form-group">{{ form.department.label_tag }}{{ form.department }}</div>
+                <div class="form-group">{{ form.position.label_tag }}{{ form.position }}</div>
+                <div class="form-group">{{ form.phone.label_tag }}{{ form.phone }}</div>
+                <div class="form-group">{{ form.profile_picture.label_tag }}{{ form.profile_picture }}</div>
+                <button class="btn-primary" type="submit">Continue</button>
+            </form>
+        {% elif enrollment_type == 'biometric' %}
+            <h2>Enroll Biometrics</h2>
+            <div id="biometric-steps">
+                <section id="face-section">
+                    <video id="faceVideo" autoplay></video>
+                    <canvas id="faceCanvas" class="hidden"></canvas>
+                    <form id="faceForm" method="post" enctype="multipart/form-data" action="{% url 'core:register_biometrics' %}">
+                        {% csrf_token %}
+                        <input type="hidden" name="face_data" id="face_data">
+                        <button type="button" id="captureFace" class="btn-primary">Capture Face</button>
+                    </form>
+                </section>
+                <hr>
+                <section id="fingerprint-section">
+                    <button type="button" id="webauthnBtn" class="btn-primary">Register Device</button>
+                </section>
+            </div>
+        {% else %}
+            <h2>Create Account</h2>
+            <form method="post" action="{% url 'core:register' %}" data-auth>
+                {% csrf_token %}
+                {{ form.non_field_errors }}
+                <div class="form-group">{{ form.username.label_tag }}{{ form.username|addattr:"autofocus" }}</div>
+                <div class="form-group">{{ form.email.label_tag }}{{ form.email }}</div>
+                <div class="form-group">{{ form.password1.label_tag }}{{ form.password1 }}</div>
+                <div class="form-group">{{ form.password2.label_tag }}{{ form.password2 }}</div>
+                <button class="btn-primary" type="submit">Register</button>
+            </form>
+        {% endif %}
+    </div>
+</main>
+<script src="{% static 'js/auth.js' %}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement production-ready authentication templates
- add neumorphic design CSS and shared auth JS
- integrate biometric and WebAuthn enrollment flows

## Testing
- `python WebAppIAM/manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6880a44233108320ac36b5c0ab330e91