### PR TITLE
Configure local WebAuthn settings

### DIFF
--- a/WebAppIAM/WebAppIAM/settings.py
+++ b/WebAppIAM/WebAppIAM/settings.py
@@ -11,6 +11,10 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
 from pathlib import Path
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -147,10 +151,12 @@ AZURE_FACE_API_ENDPOINT = 'https://your-region.api.cognitive.microsoft.com/'
 AZURE_FACE_PERSON_GROUP_ID = 'your-person-group-id'
 
 # WebAuthn Configuration
-WEBAUTHN_ENABLED = True
-WEBAUTHN_RP_ID = 'your-domain.com'  # Should match your domain
-WEBAUTHN_RP_NAME = 'Your App Name'
-WEBAUTHN_EXPECTED_ORIGIN = 'https://your-domain.com'
+# Defaults provide sensible values for local development but can be overridden
+# with environment variables for production deployments.
+WEBAUTHN_ENABLED = os.environ.get('WEBAUTHN_ENABLED', 'True') == 'True'
+WEBAUTHN_RP_ID = os.environ.get('WEBAUTHN_RP_ID', 'localhost')
+WEBAUTHN_RP_NAME = os.environ.get('WEBAUTHN_RP_NAME', 'WebAppIAM')
+WEBAUTHN_EXPECTED_ORIGIN = os.environ.get('WEBAUTHN_EXPECTED_ORIGIN', 'http://localhost:8000')
 
 # Risk Engine Weights
 RISK_FACE_WEIGHT = 0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ joblib
 numpy
 pandas
 Pillow
+python-dotenv


### PR DESCRIPTION
## Summary
- load env vars with python-dotenv
- set WebAuthn defaults for local development and use project name as RP name
- add python-dotenv to requirements

## Testing
- `pip install -r requirements.txt`
- `python manage.py test -v 2`
- `python -m compileall -q WebAppIAM`


------
https://chatgpt.com/codex/tasks/task_e_6881374559a883208be27042927ef995