### PR TITLE
Fix static JS placement in templates

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -187,5 +187,7 @@
         </main>
     </div>
 </div>
+{% endblock %}
+{% block extra_js %}
     <script src="{% static 'js/dashboard.js' %}"></script>
 {% endblock %}

--- a/WebAppIAM/core/templates/core/document_versions.html
+++ b/WebAppIAM/core/templates/core/document_versions.html
@@ -48,7 +48,8 @@
         </table>
         <p><a href="{% url 'core:document_list' %}">Back to documents</a></p>
     </main>
+{% endblock %}
+{% block extra_js %}
     <script src="{% static 'js/documents.js' %}"></script>
 {% endblock %}
-{% block extra_js %}{% endblock %}
 

--- a/WebAppIAM/core/templates/core/notifications.html
+++ b/WebAppIAM/core/templates/core/notifications.html
@@ -24,6 +24,7 @@
             {% endfor %}
         </ul>
     </main>
+{% endblock %}
+{% block extra_js %}
     <script src="{% static 'js/notifications.js' %}"></script>
 {% endblock %}
-{% block extra_js %}{% endblock %}

--- a/WebAppIAM/core/templates/core/profile_settings.html
+++ b/WebAppIAM/core/templates/core/profile_settings.html
@@ -33,6 +33,7 @@
             </form>
         </section>
     </main>
+{% endblock %}
+{% block extra_js %}
     <script src="{% static 'js/profile.js' %}"></script>
 {% endblock %}
-{% block extra_js %}{% endblock %}

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -188,5 +188,7 @@
         </main>
     </div>
 </div>
+{% endblock %}
+{% block extra_js %}
 <script src="{% static 'js/dashboard.js' %}"></script>
 {% endblock %}

--- a/scripts/check_static_templates.py
+++ b/scripts/check_static_templates.py
@@ -1,0 +1,30 @@
+import os
+import re
+from pathlib import Path
+
+TEMPLATE_DIR = Path('WebAppIAM/core/templates')
+STATIC_DIR = Path('WebAppIAM/core/static')
+
+CSS_RE = re.compile(r"static ['\"](?P<path>css/[^'\"]+)['\"]")
+JS_RE = re.compile(r"static ['\"](?P<path>js/[^'\"]+)['\"]")
+
+missing = []
+
+for html in TEMPLATE_DIR.rglob('*.html'):
+    text = html.read_text()
+    for match in CSS_RE.finditer(text):
+        path = STATIC_DIR / match.group('path')
+        if not path.exists():
+            missing.append(f"{html}: missing {path}")
+    for match in JS_RE.finditer(text):
+        path = STATIC_DIR / match.group('path')
+        if not path.exists():
+            missing.append(f"{html}: missing {path}")
+
+if missing:
+    print("Missing static files:")
+    for m in missing:
+        print(m)
+    exit(1)
+
+print('All referenced static files exist.')


### PR DESCRIPTION
## Summary
- ensure dashboard templates put scripts in `extra_js` block
- adjust other templates for consistency
- add a small script to validate static file references

## Testing
- `python scripts/check_static_templates.py`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68820ae52cf08320bd499e2b37a87870