### PR TITLE
Fix validation logic

### DIFF
--- a/ml_pipeline/deployment/deploy_models.py
+++ b/ml_pipeline/deployment/deploy_models.py
@@ -53,11 +53,13 @@ class ModelDeployer:
     def validate_model(self, model_path, model_type):
         """Run validation checks on a model"""
         # Load model and get validation report
-        data_path = os.path.join(self.base_dir, "../data/synthetic_risk_data.parquet")
+        risk_data = os.path.join(self.base_dir, "../data/synthetic_risk_data.parquet")
+        behavior_data = os.path.join(self.base_dir, "../data/synthetic_behavior_data.parquet")
         report = validate_models(
             risk_model_path=model_path if "risk" in model_type else None,
             behavior_model_path=model_path if "behavior" in model_type else None,
-            risk_data_path=data_path
+            risk_data_path=risk_data,
+            behavior_data_path=behavior_data,
         )
         
         # Save validation report


### PR DESCRIPTION
## Summary
- update validation paths to be relative to the pipeline
- calculate behavior model metrics
- pass behaviour data path in deployment

## Testing
- `python -m py_compile ml_pipeline/validation/validate_models.py ml_pipeline/deployment/deploy_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68821ef317288320a03a7ccf51d8d8cf