### PR TITLE
Fix validation logic

### DIFF
--- a/ml_pipeline/data_generation/generate_behavior_data.py
+++ b/ml_pipeline/data_generation/generate_behavior_data.py
@@ -104,10 +104,16 @@ def generate_behavior_data(users=20000, sessions_per_user=50, output_dir="../dat
             else:
                 session['avg_hold_time'] = 0
                 session['avg_flight_time'] = 0
-    
-    # Convert back to DataFrame if merged
-    if all_sessions:
+
+        # Convert back to DataFrame with merged features and recompute score
         df = pd.DataFrame(all_sessions)
+        df['behavior_anomaly_score'] = (
+            0.3 * (df['time_anomaly'] / 1440)
+            + 0.2 * df['device_anomaly']
+            + 0.2 * df['location_anomaly']
+            + 0.15 * df['action_entropy']
+            + 0.15 * df['ip_risk']
+        ).clip(0, 1)
         df.to_parquet(output_path)
         print(f"Merged keystroke features into behavior data at {output_path}")
 

--- a/ml_pipeline/deployment/deploy_models.py
+++ b/ml_pipeline/deployment/deploy_models.py
@@ -53,11 +53,13 @@ class ModelDeployer:
     def validate_model(self, model_path, model_type):
         """Run validation checks on a model"""
         # Load model and get validation report
-        data_path = os.path.join(self.base_dir, "../data/synthetic_risk_data.parquet")
+        risk_data = os.path.join(self.base_dir, "../data/synthetic_risk_data.parquet")
+        behavior_data = os.path.join(self.base_dir, "../data/synthetic_behavior_data.parquet")
         report = validate_models(
             risk_model_path=model_path if "risk" in model_type else None,
             behavior_model_path=model_path if "behavior" in model_type else None,
-            risk_data_path=data_path
+            risk_data_path=risk_data,
+            behavior_data_path=behavior_data,
         )
         
         # Save validation report


### PR DESCRIPTION
## Summary
- update validation paths to be relative to the pipeline
- calculate behavior model metrics
- pass behaviour data path in deployment
- ensure behavior data generation retains anomaly scores for validation

## Testing
- `python -m py_compile ml_pipeline/data_generation/generate_behavior_data.py ml_pipeline/validation/validate_models.py ml_pipeline/deployment/deploy_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68821ef317288320a03a7ccf51d8d8cf