### PR TITLE
Fix model output paths

### DIFF
--- a/ml_pipeline/training/train_behavior_model.py
+++ b/ml_pipeline/training/train_behavior_model.py
@@ -7,8 +7,10 @@ import joblib
 import shap
 import os
 
-def train_behavior_model(data_path="../data/synthetic_behavior_data.parquet",
-                         output_dir="../models"):
+def train_behavior_model(data_path=None, output_dir=None):
+    base_dir = os.path.join(os.path.dirname(__file__), "..")
+    data_path = data_path or os.path.join(base_dir, "data", "synthetic_behavior_data.parquet")
+    output_dir = output_dir or os.path.join(base_dir, "models")
     os.makedirs(output_dir, exist_ok=True)
     
     # Load data

--- a/ml_pipeline/training/train_risk_model.py
+++ b/ml_pipeline/training/train_risk_model.py
@@ -8,8 +8,10 @@ import joblib
 import shap
 import os
 
-def train_risk_model(data_path="../data/synthetic_risk_data.parquet", 
-                     output_dir="../models"):
+def train_risk_model(data_path=None, output_dir=None):
+    base_dir = os.path.join(os.path.dirname(__file__), "..")
+    data_path = data_path or os.path.join(base_dir, "data", "synthetic_risk_data.parquet")
+    output_dir = output_dir or os.path.join(base_dir, "models")
     os.makedirs(output_dir, exist_ok=True)
     
     # Load data


### PR DESCRIPTION
## Summary
- save training outputs relative to the training package
- include an empty models directory

## Testing
- `python WebAppIAM/manage.py test core -v 0`


------
https://chatgpt.com/codex/tasks/task_e_688236724ea88320bde6139731aa1afa