### PR TITLE
Add login and register pages with inline styles and scripts

### DIFF
--- a/WebAppIAM/core/templates/core/login.html
+++ b/WebAppIAM/core/templates/core/login.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f5f5f5;
+            margin: 0; padding: 0;
+        }
+        .container {
+            max-width: 400px;
+            margin: 40px auto;
+            background: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 { text-align: center; }
+        form { display: flex; flex-direction: column; }
+        label { margin-top: 10px; }
+        input[type="text"], input[type="password"], input[type="file"] {
+            padding: 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            margin-top: 5px;
+        }
+        button {
+            margin-top: 15px;
+            padding: 10px;
+            background: #007bff;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover { background: #0056b3; }
+        .messages { margin-bottom: 15px; }
+        .messages li { list-style: none; padding: 10px; border-radius: 4px; margin-bottom: 5px; }
+        .messages .error { background: #f8d7da; color: #721c24; }
+        .messages .success { background: #d4edda; color: #155724; }
+        .hidden { display: none; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Login</h1>
+    {% if messages %}
+    <ul class="messages">
+        {% for m in messages %}
+            <li class="{{ m.tags }}">{{ m }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    {% if show_biometric_verification %}
+        <p>Please verify your identity.</p>
+        <form id="faceVerifyForm" method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            <label for="face_image">Face image</label>
+            <input type="file" id="face_image" name="face_image" accept="image/*">
+            <button type="submit">Verify Face</button>
+        </form>
+        {% if webauthn_enabled %}
+            <button id="fpButton" type="button">Use Fingerprint</button>
+        {% endif %}
+    {% else %}
+        <form id="loginForm" method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit">Login</button>
+        </form>
+    {% endif %}
+</div>
+<script>
+(function(){
+    const csrftoken = '{{ csrf_token }}';
+    {% if not show_biometric_verification %}
+    let events = [];
+    function record(e){ events.push({type:e.type, key:e.key, time:Date.now()}); }
+    document.getElementById('id_username').addEventListener('keydown', record);
+    document.getElementById('id_username').addEventListener('keyup', record);
+    document.getElementById('id_password').addEventListener('keydown', record);
+    document.getElementById('id_password').addEventListener('keyup', record);
+    document.getElementById('loginForm').addEventListener('submit', function(){
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'keystroke_data';
+        input.value = JSON.stringify(events);
+        this.appendChild(input);
+    });
+    {% else %}
+    // biometric verification handlers
+    const faceForm = document.getElementById('faceVerifyForm');
+    if(faceForm){
+        faceForm.addEventListener('submit', function(){
+            // simple validation
+            const file = document.getElementById('face_image').value;
+            if(!file){ alert('Please choose a face image'); return false; }
+        });
+    }
+    {% if webauthn_enabled %}
+    document.getElementById('fpButton').addEventListener('click', async function(){
+        try{
+            const optResp = await fetch('{% url "core:webauthn_authentication_options" %}', {
+                method: 'POST',
+                headers: {'X-CSRFToken': csrftoken}
+            });
+            const options = await optResp.json();
+            ['challenge'].forEach(k => options[k] = Uint8Array.from(atob(options[k]), c=>c.charCodeAt(0)));
+            if(options.allowCredentials){
+                options.allowCredentials = options.allowCredentials.map(c=>{
+                    c.id = Uint8Array.from(atob(c.id), ch=>ch.charCodeAt(0));
+                    return c;
+                });
+            }
+            const cred = await navigator.credentials.get({publicKey: options});
+            const data = {
+                id: cred.id,
+                rawId: btoa(String.fromCharCode(...new Uint8Array(cred.rawId))),
+                type: cred.type,
+                response: {
+                    clientDataJSON: btoa(String.fromCharCode(...new Uint8Array(cred.response.clientDataJSON))),
+                    authenticatorData: btoa(String.fromCharCode(...new Uint8Array(cred.response.authenticatorData))),
+                    signature: btoa(String.fromCharCode(...new Uint8Array(cred.response.signature))),
+                    userHandle: cred.response.userHandle ? btoa(String.fromCharCode(...new Uint8Array(cred.response.userHandle))) : null
+                }
+            };
+            const verifyResp = await fetch('{% url "core:webauthn_authentication_verify" %}', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrftoken},
+                body: JSON.stringify(data)
+            });
+            const result = await verifyResp.json();
+            if(result.status === 'success'){
+                window.location.href = result.redirect;
+            }else{
+                alert(result.message || 'Authentication failed');
+            }
+        }catch(e){ alert('Fingerprint verification failed'); }
+    });
+    {% endif %}
+    {% endif %}
+})();
+</script>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/register.html
+++ b/WebAppIAM/core/templates/core/register.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#f5f5f5; margin:0; padding:0; }
+        .container { max-width:500px; margin:40px auto; background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+        h1 { text-align:center; }
+        form { display:flex; flex-direction:column; }
+        label { margin-top:10px; }
+        input, select { padding:8px; border:1px solid #ccc; border-radius:4px; margin-top:5px; }
+        button { margin-top:15px; padding:10px; background:#28a745; color:#fff; border:none; border-radius:4px; cursor:pointer; }
+        button:hover { background:#1e7e34; }
+        .messages { margin-bottom:15px; }
+        .messages li { list-style:none; padding:10px; border-radius:4px; margin-bottom:5px; }
+        .messages .error { background:#f8d7da; color:#721c24; }
+        .messages .success { background:#d4edda; color:#155724; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Register</h1>
+    {% if messages %}
+    <ul class="messages">
+        {% for m in messages %}<li class="{{ m.tags }}">{{ m }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+
+    {% if show_profile_completion %}
+        <h2>Complete Your Profile</h2>
+        <form method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit">Continue</button>
+        </form>
+    {% elif enrollment_type == 'biometric' %}
+        <h2>Enroll Biometrics</h2>
+        <form id="faceEnroll" method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            <label for="face_data">Face image</label>
+            <input type="file" id="face_data" name="face_data" accept="image/*">
+            <button type="submit">Enroll Face</button>
+        </form>
+        <hr>
+        <button id="enrollFingerprint" type="button">Enroll Fingerprint</button>
+    {% else %}
+        <form method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit">Register</button>
+        </form>
+    {% endif %}
+</div>
+<script>
+(function(){
+    const csrftoken = '{{ csrf_token }}';
+    {% if enrollment_type == 'biometric' %}
+    document.getElementById('enrollFingerprint').addEventListener('click', async function(){
+        try {
+            const optResp = await fetch('{% url "core:webauthn_registration_options" %}', {
+                method: 'POST',
+                headers: {'X-CSRFToken': csrftoken}
+            });
+            const options = await optResp.json();
+            ['challenge','user.id'].forEach(k=>{ if(options[k]) options[k]=Uint8Array.from(atob(options[k]),c=>c.charCodeAt(0)); });
+            if(options.excludeCredentials){
+                options.excludeCredentials = options.excludeCredentials.map(c=>{ c.id=Uint8Array.from(atob(c.id),ch=>ch.charCodeAt(0)); return c; });
+            }
+            const cred = await navigator.credentials.create({publicKey: options});
+            const data = {
+                id: cred.id,
+                rawId: btoa(String.fromCharCode(...new Uint8Array(cred.rawId))),
+                type: cred.type,
+                response: {
+                    clientDataJSON: btoa(String.fromCharCode(...new Uint8Array(cred.response.clientDataJSON))),
+                    attestationObject: btoa(String.fromCharCode(...new Uint8Array(cred.response.attestationObject)))
+                }
+            };
+            const verifyResp = await fetch('{% url "core:webauthn_registration_verify" %}', {
+                method: 'POST',
+                headers: {'Content-Type':'application/json','X-CSRFToken': csrftoken},
+                body: JSON.stringify(data)
+            });
+            const result = await verifyResp.json();
+            if(result.status === 'success'){
+                if(result.redirect){ window.location.href = result.redirect; }
+                else alert('Fingerprint enrollment successful');
+            }else{
+                alert(result.message || 'Enrollment failed');
+            }
+        } catch(e){ alert('Fingerprint enrollment failed'); }
+    });
+    {% endif %}
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build out `login.html` with keystroke capture and biometric verification
- build out `register.html` to support profile completion and biometric enrollment

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68824e30b7b48320abab68244d263cff