### PR TITLE
Implement password reset templates

### DIFF
--- a/WebAppIAM/core/templates/core/password_reset.html
+++ b/WebAppIAM/core/templates/core/password_reset.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Password Reset</title>
+    <style>
+        body {font-family: Arial, sans-serif; background:#f0f2f5; display:flex; align-items:center; justify-content:center; height:100vh;}
+        .reset-container {background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); width:300px;}
+        h2 {margin-top:0;}
+        .form-group {margin-bottom:15px;}
+        .form-group label {display:block; margin-bottom:5px;}
+        .form-group input {width:100%; padding:8px; box-sizing:border-box;}
+        .error {color:#b00020; font-size:0.9em;}
+        button {width:100%; padding:10px; background:#007bff; color:#fff; border:none; border-radius:4px; cursor:pointer;}
+        button:disabled {background:#a0a0a0; cursor:not-allowed;}
+        .link {margin-top:10px; text-align:center;}
+    </style>
+</head>
+<body>
+<div class="reset-container">
+    <h2>Password Reset</h2>
+    <form method="post" id="reset-form" novalidate>
+        {% csrf_token %}
+        <div class="form-group">
+            {{ form.email.label_tag }}
+            {{ form.email }}
+            {% if form.email.errors %}
+                <div class="error">{{ form.email.errors|striptags }}</div>
+            {% endif %}
+        </div>
+        <button type="submit" id="submit-btn">Send Reset Link</button>
+    </form>
+    <div class="link"><a href="{% url 'core:login' %}">Back to login</a></div>
+</div>
+<script>
+document.getElementById('reset-form').addEventListener('submit', function(e) {
+    var emailInput = document.querySelector('input[name="email"]');
+    if(!emailInput.value.trim()) {
+        e.preventDefault();
+        alert('Please enter your email address.');
+    }
+});
+</script>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/password_reset_complete.html
+++ b/WebAppIAM/core/templates/core/password_reset_complete.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Password Reset Complete</title>
+    <style>
+        body {font-family: Arial, sans-serif; background:#f0f2f5; display:flex; align-items:center; justify-content:center; height:100vh;}
+        .message {background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); text-align:center;}
+        a {color:#007bff;}
+    </style>
+</head>
+<body>
+<div class="message">
+    <p>Your password has been reset successfully.</p>
+    <p><a href="{% url 'core:login' %}">Login</a></p>
+</div>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/password_reset_confirm.html
+++ b/WebAppIAM/core/templates/core/password_reset_confirm.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Set New Password</title>
+    <style>
+        body {font-family: Arial, sans-serif; background:#f0f2f5; display:flex; align-items:center; justify-content:center; height:100vh;}
+        .reset-box {background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); width:300px;}
+        h2 {margin-top:0;}
+        .form-group {margin-bottom:15px;}
+        label {display:block; margin-bottom:5px;}
+        input {width:100%; padding:8px; box-sizing:border-box;}
+        .error {color:#b00020; font-size:0.9em;}
+        button {width:100%; padding:10px; background:#007bff; color:#fff; border:none; border-radius:4px;}
+        .link {text-align:center; margin-top:10px;}
+    </style>
+</head>
+<body>
+<div class="reset-box">
+    <h2>Set New Password</h2>
+    <form method="post" id="confirm-form" novalidate>
+        {% csrf_token %}
+        {% if form.non_field_errors %}
+            <div class="error">{{ form.non_field_errors|striptags }}</div>
+        {% endif %}
+        <div class="form-group">
+            {{ form.password1.label_tag }}
+            {{ form.password1 }}
+            {% if form.password1.errors %}
+                <div class="error">{{ form.password1.errors|striptags }}</div>
+            {% endif %}
+        </div>
+        <div class="form-group">
+            {{ form.password2.label_tag }}
+            {{ form.password2 }}
+            {% if form.password2.errors %}
+                <div class="error">{{ form.password2.errors|striptags }}</div>
+            {% endif %}
+        </div>
+        <button type="submit" id="confirm-btn">Reset Password</button>
+    </form>
+    <div class="link"><a href="{% url 'core:login' %}">Back to login</a></div>
+</div>
+<script>
+document.getElementById('confirm-form').addEventListener('submit', function(e) {
+    var p1 = document.querySelector('input[name="password1"]');
+    var p2 = document.querySelector('input[name="password2"]');
+    if(p1.value !== p2.value) {
+        e.preventDefault();
+        alert('Passwords do not match.');
+    }
+});
+</script>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/password_reset_done.html
+++ b/WebAppIAM/core/templates/core/password_reset_done.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Reset Email Sent</title>
+    <style>
+        body {font-family: Arial, sans-serif; background:#f0f2f5; display:flex; align-items:center; justify-content:center; height:100vh;}
+        .message-box {background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); text-align:center;}
+        a {color:#007bff;}
+    </style>
+</head>
+<body>
+<div class="message-box">
+    <p>If an account with the provided email exists, a password reset link has been sent.</p>
+    <p><a href="{% url 'core:login' %}">Return to login</a></p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create password reset HTML templates with inline CSS and JS
- add password reset confirmation form and pages

## Testing
- `pytest -q` *(fails: ImproperlyConfigured)*
- `python WebAppIAM/manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68824f310ad48320b26bf03bcdce87d1