### PR TITLE
Add HTML templates with embedded styles

### DIFF
--- a/WebAppIAM/core/templates/core/access_denied.html
+++ b/WebAppIAM/core/templates/core/access_denied.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Access Denied</title>
+    <style>
+        body {font-family: Arial, sans-serif;background:#f0f2f5;margin:0;}
+        .container {max-width:600px;margin:80px auto;padding:20px;background:#fff;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,0.1);text-align:center;}
+        h1 {color:#c0392b;margin-bottom:10px;}
+        .reason {margin:20px 0;font-size:1.1em;color:#555;}
+        .login-link {display:inline-block;padding:10px 20px;background:#3498db;color:#fff;text-decoration:none;border-radius:5px;}
+    </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            var seconds = 10;
+            var timer = document.getElementById('timer');
+            var interval = setInterval(function () {
+                seconds--;
+                if (timer) timer.textContent = seconds;
+                if (seconds <= 0) {
+                    clearInterval(interval);
+                    window.location.href = "{% url 'core:login' %}";
+                }
+            }, 1000);
+        });
+    </script>
+</head>
+<body>
+<div class="container">
+    <h1>Access Denied</h1>
+    <p class="reason">{{ reason }}</p>
+    <p>You will be redirected to the login page in <span id="timer">10</span> seconds.</p>
+    <a class="login-link" href="{% url 'core:login' %}">Return to Login</a>
+</div>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/device_management.html
+++ b/WebAppIAM/core/templates/core/device_management.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Device Management</title>
+    <style>
+        body{font-family:Arial, sans-serif;background:#f5f7fa;margin:0;}
+        .container{max-width:960px;margin:40px auto;padding:20px;background:#fff;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);}
+        h1{margin-top:0;text-align:center;color:#333;}
+        table{width:100%;border-collapse:collapse;margin-top:20px;}
+        th,td{padding:8px 12px;border-bottom:1px solid #ddd;text-align:left;}
+        th{background:#f0f2f5;}
+        tr.trusted{background:#e8f8e8;}
+        .actions form{display:inline;}
+        .actions button{margin-right:4px;padding:4px 8px;border:none;border-radius:4px;cursor:pointer;}
+        .trust-btn{background:#2ecc71;color:#fff;}
+        .remove-btn{background:#e74c3c;color:#fff;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Device Management</h1>
+    <table>
+        <thead>
+        <tr>
+            <th>Name</th>
+            <th>Browser / OS</th>
+            <th>Type</th>
+            <th>Last Seen</th>
+            <th>IP</th>
+            <th>Location</th>
+            <th>Uses</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for device in devices %}
+        <tr class="{% if device.is_trusted %}trusted{% endif %}">
+            <td>{{ device.device_name|default:'Unknown' }}</td>
+            <td>{{ device.browser }} / {{ device.operating_system }}</td>
+            <td>{{ device.device_type }}</td>
+            <td>{{ device.last_seen }}</td>
+            <td>{{ device.last_ip|default:'-' }}</td>
+            <td>{{ device.last_location|default:'-' }}</td>
+            <td>{{ device.times_used }}</td>
+            <td class="actions">
+                {% if not device.is_trusted %}
+                <form method="post" action="{% url 'core:trust_device' device.id %}">{% csrf_token %}
+                    <button type="submit" class="trust-btn">Trust</button>
+                </form>
+                {% endif %}
+                <form method="post" action="{% url 'core:remove_device' device.id %}" onsubmit="return confirm('Remove this device?');">{% csrf_token %}
+                    <button type="submit" class="remove-btn">Remove</button>
+                </form>
+            </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="8">No devices found.</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/document_versions.html
+++ b/WebAppIAM/core/templates/core/document_versions.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document Versions - {{ document.title }}</title>
+    <style>
+        body{font-family:Arial, sans-serif;background:#f5f5f5;margin:0;}
+        .container{max-width:960px;margin:40px auto;padding:20px;background:#fff;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);}
+        h1{margin-top:0;text-align:center;}
+        form.filters input{padding:6px;margin-right:10px;}
+        table{width:100%;border-collapse:collapse;margin-top:20px;}
+        th,td{padding:8px 12px;border-bottom:1px solid #ddd;text-align:left;}
+        th{background:#f0f2f5;}
+        .status-badge{padding:3px 8px;border-radius:4px;color:#fff;display:inline-block;font-size:0.85em;}
+        .status-success{background:#2ecc71;}
+        .status-danger{background:#e74c3c;}
+        .status-warning{background:#f1c40f;color:#000;}
+        .status-secondary{background:#95a5a6;}
+    </style>
+    <script>
+        function restoreVersion(id, csrfToken){
+            if(confirm('Restore this version?')){
+                fetch('{% url "core:restore_document_version" 0 %}'.replace('0', id), {
+                    method:'POST',
+                    headers:{'X-CSRFToken': csrfToken}
+                }).then(function(){ location.reload(); });
+            }
+        }
+    </script>
+</head>
+<body>
+<div class="container">
+    <h1>Versions of {{ document.title }}</h1>
+    <form method="get" class="filters">
+        <input type="text" name="q" placeholder="Search" value="{{ query }}">
+        <input type="date" name="date_from" value="{{ date_from }}">
+        <input type="date" name="date_to" value="{{ date_to }}">
+        <input type="number" name="version" min="1" placeholder="Version" value="{{ version }}">
+        <button type="submit">Filter</button>
+    </form>
+    <table>
+        <thead>
+        <tr>
+            <th>Version</th>
+            <th>Uploaded</th>
+            <th>Uploader</th>
+            <th>Size</th>
+            <th>Status</th>
+            {% if user.role == 'ADMIN' %}<th>Actions</th>{% endif %}
+        </tr>
+        </thead>
+        <tbody>
+        {% for v in versions %}
+        <tr>
+            <td>{{ v.version }}</td>
+            <td>{{ v.created_at }}</td>
+            <td>{{ v.uploaded_by }}</td>
+            <td>{{ v.file_size }} bytes</td>
+            <td><span class="status-badge status-{{ v.get_status_class }}">{{ v.get_status }}</span></td>
+            {% if user.role == 'ADMIN' %}
+            <td>
+                {% if v.deleted %}
+                <button type="button" onclick="restoreVersion({{ v.id }}, '{{ csrf_token }}')">Restore</button>
+                {% else %}-{% endif %}
+            </td>
+            {% endif %}
+        </tr>
+        {% empty %}
+        <tr><td colspan="6">No versions found.</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement **access_denied.html** with message, redirect and styling
- create **device_management.html** listing user devices with actions
- implement **document_versions.html** showing versions with filtering and admin restore option

## Testing
- `python WebAppIAM/manage.py test core -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68824fa88dd48320a7f6fd9606d360b5