### PR TITLE
Add emergency templates

### DIFF
--- a/WebAppIAM/core/templates/core/emergency_access.html
+++ b/WebAppIAM/core/templates/core/emergency_access.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Emergency Access</title>
+    <style>
+        body{font-family:Arial, sans-serif;background:#f5f5f5;margin:0;padding:0;}
+        .container{max-width:800px;margin:40px auto;background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+        h1{text-align:center;}
+        form{margin-top:20px;padding:10px;border:1px solid #ddd;border-radius:4px;}
+        label{display:block;margin-top:10px;}
+        input[type="text"]{width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;margin-top:5px;}
+        button{margin-top:10px;padding:8px 12px;background:#007bff;color:#fff;border:none;border-radius:4px;cursor:pointer;}
+        button:hover{background:#0056b3;}
+        ul.messages{padding:0;list-style:none;}
+        ul.messages li{margin-bottom:10px;padding:10px;border-radius:4px;}
+        .error{background:#f8d7da;color:#721c24;}
+        .success{background:#d4edda;color:#155724;}
+        .warning{background:#fff3cd;color:#856404;}
+        .token-box{background:#f0f2f5;padding:10px;border-radius:4px;margin-top:10px;font-family:monospace;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Emergency Access Dashboard</h1>
+    {% if messages %}
+    <ul class="messages">
+        {% for m in messages %}
+            <li class="{{ m.tags }}">{{ m }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    <p>Emergency mode is currently <strong>{{ emergency_mode|yesno:"ACTIVE,INACTIVE" }}</strong>.</p>
+
+    <form method="post" action="{% url 'core:activate_emergency' %}">
+        {% csrf_token %}
+        <h3>Activate Emergency Mode</h3>
+        <label for="activate_reason">Reason</label>
+        <input id="activate_reason" type="text" name="reason" required>
+        <button type="submit">Activate</button>
+    </form>
+
+    <form method="post" action="{% url 'core:deactivate_emergency' %}" id="deactivateForm">
+        {% csrf_token %}
+        <h3>Deactivate Emergency Mode</h3>
+        <button type="submit">Deactivate</button>
+    </form>
+
+    <form method="post" action="{% url 'core:generate_emergency_token' %}">
+        {% csrf_token %}
+        <h3>Generate Emergency Token</h3>
+        <label for="username">Username</label>
+        <input id="username" type="text" name="username" required>
+        <label for="token_reason">Reason</label>
+        <input id="token_reason" type="text" name="reason" required>
+        <button type="submit">Generate Token</button>
+    </form>
+
+    {% if emergency_token %}
+    <div class="token-box">
+        Token for {{ token_username }}: <code>{{ emergency_token }}</code>
+    </div>
+    {% endif %}
+</div>
+<script>
+(function(){
+    const deactivate = document.getElementById('deactivateForm');
+    if(deactivate){
+        deactivate.addEventListener('submit', function(e){
+            if(!confirm('Deactivate emergency mode?')) e.preventDefault();
+        });
+    }
+})();
+</script>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/emergency_login.html
+++ b/WebAppIAM/core/templates/core/emergency_login.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Emergency Login</title>
+    <style>
+        body{font-family:Arial,sans-serif;background:#f5f5f5;margin:0;padding:0;}
+        .container{max-width:400px;margin:40px auto;background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+        h1{text-align:center;}
+        label{display:block;margin-top:10px;}
+        input[type="text"]{width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;margin-top:5px;}
+        button{margin-top:15px;padding:10px;background:#007bff;color:#fff;border:none;border-radius:4px;cursor:pointer;}
+        button:hover{background:#0056b3;}
+        .error{background:#f8d7da;color:#721c24;padding:10px;border-radius:4px;margin-bottom:10px;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Emergency Login</h1>
+    {% if error_message %}<div class="error">{{ error_message }}</div>{% endif %}
+    <form method="post" action="{% url 'core:emergency_login' %}">
+        {% csrf_token %}
+        <label for="username">Username</label>
+        <input id="username" type="text" name="username" required>
+        <label for="token">Emergency Token</label>
+        <input id="token" type="text" name="emergency_token" required>
+        <button type="submit">Login</button>
+    </form>
+</div>
+</body>
+</html>

--- a/WebAppIAM/core/templates/core/system_status.html
+++ b/WebAppIAM/core/templates/core/system_status.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>System Status</title>
+    <style>
+        body{font-family:Arial,sans-serif;background:#f5f5f5;margin:0;padding:0;}
+        .container{max-width:800px;margin:40px auto;background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+        h1{text-align:center;}
+        table{width:100%;border-collapse:collapse;margin-top:15px;}
+        th,td{border:1px solid #ddd;padding:8px;text-align:left;}
+        th{background:#f0f0f0;}
+        .feature form{display:inline;}
+        button{padding:6px 10px;background:#007bff;color:#fff;border:none;border-radius:4px;cursor:pointer;}
+        button:hover{background:#0056b3;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>System Status</h1>
+    <p>Overall Status: <strong>{{ system_status.status|upper }}</strong></p>
+    <p>Response Time: <span id="resp">{{ system_status.response_time_ms }} ms</span></p>
+    <table>
+        <thead>
+            <tr><th>Service</th><th>Status</th><th>Required</th></tr>
+        </thead>
+        <tbody>
+        {% for name, svc in system_status.services.items %}
+            <tr>
+                <td>{{ name }}</td>
+                <td>{{ svc.status }}</td>
+                <td>{{ svc.required }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <h2>Feature Flags</h2>
+    <div class="feature">
+        <p>FACE_API_ENABLED: {{ settings.FACE_API_ENABLED }}</p>
+        <form method="post" action="{% url 'core:toggle_feature' %}">
+            {% csrf_token %}
+            <input type="hidden" name="feature" value="FACE_API_ENABLED">
+            <input type="hidden" name="redirect_url" value="{{ request.path }}">
+            <button type="submit">Toggle</button>
+        </form>
+    </div>
+    <div class="feature">
+        <p>RISK_ENGINE_BYPASS: {{ settings.RISK_ENGINE_BYPASS }}</p>
+        <form method="post" action="{% url 'core:toggle_feature' %}">
+            {% csrf_token %}
+            <input type="hidden" name="feature" value="RISK_ENGINE_BYPASS">
+            <input type="hidden" name="redirect_url" value="{{ request.path }}">
+            <button type="submit">Toggle</button>
+        </form>
+    </div>
+</div>
+<script>
+(function(){
+    if({{ system_status.response_time_ms }} === 0){
+        var ts = {{ system_status.timestamp }} * 1000;
+        document.getElementById('resp').textContent = (Date.now() - ts) + ' ms';
+    }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fill in `emergency_access.html` with activate/deactivate and token generation forms
- create simple `emergency_login.html`
- implement system status dashboard template showing services and feature toggles

## Testing
- `python WebAppIAM/manage.py test core`

------
https://chatgpt.com/codex/tasks/task_e_68825de4d848832086c96615cfe2e541