### PR TITLE
Fix missing complete_profile URL

### DIFF
--- a/WebAppIAM/core/urls.py
+++ b/WebAppIAM/core/urls.py
@@ -52,6 +52,7 @@ urlpatterns = [
     path('admin/system/toggle-feature/', views.toggle_feature, name='toggle_feature'),
 
     # Profile Management
+    path('complete_profile/', views.complete_profile, name='complete_profile'),
     path('profile/settings/', views.profile_settings, name='profile_settings'),
 
     # Document Management


### PR DESCRIPTION
## Summary
- add URL pattern for `complete_profile`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68826a37e28c83209824bfe3069dc00e