### PR TITLE
Fix staff dashboard greeting and add notification URL

### DIFF
--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -20,7 +20,7 @@
 </head>
 <body>
 <div class="container">
-    <h1>Welcome, {{ user.first_name or user.username }}</h1>
+    <h1>Welcome, {% firstof user.first_name user.username %}</h1>
     <nav>
         <a href="{% url 'core:staff_dashboard' %}">Home</a>
         <a href="{% url 'core:document_list' %}">Documents</a>

--- a/WebAppIAM/core/urls.py
+++ b/WebAppIAM/core/urls.py
@@ -76,4 +76,5 @@ urlpatterns = [
     # Notification System
     path('notifications/', views.notifications_view, name='notifications'),
     path('notifications/dismiss/<int:notification_id>/', views.dismiss_device_notification, name='dismiss_device_notification'),
+    path('notifications/mark_read/<int:notification_id>/', views.mark_notification_read, name='mark_notification_read'),
 ]


### PR DESCRIPTION
## Summary
- use `firstof` template tag for fallback greeting
- include route for reading notifications

## Testing
- `python scripts/check_static_templates.py`
- `python WebAppIAM/manage.py test core`


------
https://chatgpt.com/codex/tasks/task_e_688274939b3483209fedbf46cb04c395