### PR TITLE
Implement login JSON contract and fix profile flows

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -565,7 +565,7 @@
             <section class="section" data-view="upload">
                 <div class="card">
                     <h2>Upload Document</h2>
-                    <form method="post" enctype="multipart/form-data">
+                    <form method="post" action="{% url 'core:update_profile' %}" enctype="multipart/form-data">
                         {% csrf_token %}
                         {{ form.as_p }}
                         <button class="btn" type="submit">Upload</button>
@@ -688,7 +688,11 @@
         });
     }
 
-    const csrftoken = '{{ csrf_token }}';
+    function getCookie(name) {
+        const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+        return match ? match[2] : null;
+    }
+    const csrftoken = getCookie('csrftoken');
 
     // Mark a single notification read on click
     document.querySelectorAll('.alert[data-id]').forEach(function (el) {

--- a/WebAppIAM/core/templates/core/complete_profile.html
+++ b/WebAppIAM/core/templates/core/complete_profile.html
@@ -88,7 +88,7 @@
             gap:6px;
         }
         form p > label{
-            font-size:. ninefive-rem;
+            font-size:.95rem;
             color:var(--text-dim);
         }
 

--- a/WebAppIAM/core/templates/core/enroll_biometrics.html
+++ b/WebAppIAM/core/templates/core/enroll_biometrics.html
@@ -385,9 +385,7 @@
 
 <!-- Safer way to pass JSON from Django to JS -->
 {% if webauthn_options %}
-<script id="webauthn-options" type="application/json">
-    {{ webauthn_options|json_script:"webauthn-options" }}
-</script>
+{{ webauthn_options|json_script:"webauthn-options" }}
 {% endif %}
 
 <script>

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -528,7 +528,7 @@
                     </ul>
                     {% endif %}
 
-                    <form method="post" enctype="multipart/form-data">
+                    <form method="post" action="{% url 'core:update_profile' %}" enctype="multipart/form-data">
                         {% csrf_token %}
                         {{ profile_form.as_p }}
                         <button class="btn" type="submit">Update Profile</button>
@@ -537,7 +537,7 @@
                     <hr style="border-color: var(--border); margin: 24px 0;">
 
                     <h3>Change Password</h3>
-                    <form method="post">
+                    <form method="post" action="{% url 'core:change_password' %}">
                         {% csrf_token %}
                         {{ password_form.as_p }}
                         <button class="btn" type="submit">Change Password</button>

--- a/WebAppIAM/core/urls.py
+++ b/WebAppIAM/core/urls.py
@@ -42,6 +42,8 @@ urlpatterns = [
     # Profile Management
     path('complete_profile/', views.complete_profile, name='complete_profile'),
     path('profile/settings/', views.profile_settings, name='profile_settings'),
+    path('profile/update/', views.update_profile, name='update_profile'),
+    path('profile/change_password/', views.change_password, name='change_password'),
 
     # Document Management
     path('documents/', views.document_list, name='document_list'),
@@ -63,4 +65,5 @@ urlpatterns = [
     path('notifications/', views.notifications_view, name='notifications'),
     path('notifications/dismiss/<int:notification_id>/', views.dismiss_device_notification, name='dismiss_device_notification'),
     path('notifications/mark_read/<int:notification_id>/', views.mark_notification_read, name='mark_notification_read'),
+    path('notifications/mark_all/', views.mark_all_notifications_read, name='mark_all_notifications_read'),
 ]


### PR DESCRIPTION
## Summary
- clean up biometric options JSON
- correct profile CSS typo
- use cookie-based CSRF in admin scripts
- split profile update & password change endpoints
- add mark-all-notifications endpoint
- audit and guard admin actions
- support AJAX login responses

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c42089588320b3d2a729088078ea