### PR TITLE
Fix document encryption usage and reenroll view

### DIFF
--- a/WebAppIAM/core/admin.py
+++ b/WebAppIAM/core/admin.py
@@ -6,7 +6,7 @@ from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 class UserAdmin(BaseUserAdmin):
     list_display = ('username', 'role', 'has_biometrics', 'is_active', 'is_staff')
     list_filter = ('role', 'is_active', 'is_staff')
-    actions = ['lock_user', 'unlock_user', 'force_reenroll']
+    actions = ['lock_user', 'unlock_user']
 
     def has_biometrics(self, obj):
         return obj.has_biometrics
@@ -21,10 +21,6 @@ class UserAdmin(BaseUserAdmin):
         queryset.update(is_active=True)
     unlock_user.short_description = 'Unlock selected users'
 
-    def force_reenroll(self, request, queryset):
-        for user in queryset:
-            user.require_reenrollment()
-    force_reenroll.short_description = 'Force biometric re-enrollment'
 
 @admin.register(UserBehaviorProfile)
 class UserBehaviorProfileAdmin(admin.ModelAdmin):

--- a/WebAppIAM/core/urls.py
+++ b/WebAppIAM/core/urls.py
@@ -36,7 +36,6 @@ urlpatterns = [
     path('admin/users/activate/<int:user_id>/', views.activate_user, name='activate_user'),
     path('admin/users/lock/<int:user_id>/', views.lock_user, name='lock_user'),
     path('admin/users/unlock/<int:user_id>/', views.unlock_user, name='unlock_user'),
-    path('admin/users/force-reenroll/<int:user_id>/', views.force_reenroll, name='force_reenroll'),
 
 
     # Profile Management


### PR DESCRIPTION
## Summary
- use encrypted_file field in upload and download views
- update biometric re-enroll view to use the current model helper
- remove biometric reenrollment route and admin action

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883374870a48320bbddde4c0fee5e4e