### PR TITLE
Improve password reset validation

### DIFF
--- a/WebAppIAM/WebAppIAM/settings.py
+++ b/WebAppIAM/WebAppIAM/settings.py
@@ -144,6 +144,7 @@ EMAIL_HOST_USER = 'webappIAM@outlook.com'
 EMAIL_HOST_PASSWORD = 'testcase@123456'
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', 'webappIAM@outlook.com')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', 'testcase@123456')
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER)
 
 # Azure Face API
 AZURE_FACE_API_KEY = os.environ.get('AZURE_FACE_API_KEY',

--- a/WebAppIAM/core/forms.py
+++ b/WebAppIAM/core/forms.py
@@ -127,6 +127,12 @@ class PasswordResetForm(forms.Form):
         widget=forms.EmailInput(attrs={'class': 'form-control', 'placeholder': 'Enter your email'})
     )
 
+    def clean_email(self):
+        email = self.cleaned_data['email']
+        if not User.objects.filter(email=email).exists():
+            raise forms.ValidationError("User with this email does not exist.")
+        return email
+
 class PasswordResetConfirmForm(forms.Form):
     password1 = forms.CharField(
         label="New password",

--- a/WebAppIAM/core/test_password_reset.py
+++ b/WebAppIAM/core/test_password_reset.py
@@ -1,0 +1,34 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth import get_user_model
+from unittest.mock import patch
+import os
+import django
+from django.core.management import call_command
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'WebAppIAM.settings')
+django.setup()
+call_command('migrate', run_syncdb=True, verbosity=0)
+
+from .views import password_reset_request
+
+User = get_user_model()
+
+class PasswordResetTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username='foo', password='bar', email='foo@example.com')
+
+    def test_unknown_email_shows_error(self):
+        request = self.factory.post('/', {'email': 'unknown@example.com'})
+        response = password_reset_request(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'User with this email does not exist.', response.content)
+
+    @patch('core.views.send_mail')
+    def test_valid_email_sends_reset(self, mock_send):
+        request = self.factory.post('/', {'email': 'foo@example.com'}, HTTP_HOST='testserver')
+        with self.settings(ALLOWED_HOSTS=['testserver']):
+            response = password_reset_request(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Reset Email Sent', response.content)
+        self.assertTrue(mock_send.called)

--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -1387,40 +1387,36 @@ def password_reset_request(request):
         form = PasswordResetForm(request.POST)
         if form.is_valid():
             email = form.cleaned_data['email']
-            try:
-                user = User.objects.get(email=email)
-                
-                # Generate token and expiration
-                token = Fernet.generate_key().decode()
-                expiration = timezone.now() + timedelta(hours=24)
-                
-                user.email_verification_token = token
-                user.email_verification_expiration = expiration
-                user.save()
-                
-                # Send password reset email
-                reset_url = request.build_absolute_uri(
-                    reverse('core:password_reset_confirm', kwargs={'user_id': user.id, 'token': token})
-                )
-                
-                subject = 'Password Reset Request'
-                message = render_to_string('emails/password_reset.html', {
-                    'user': user,
-                    'reset_link': reset_url
-                })
-                
-                send_mail(
-                    subject,
-                    message,
-                    settings.DEFAULT_FROM_EMAIL,
-                    [user.email],
-                    fail_silently=False
-                )
-                
-                return render(request, 'core/password_reset_done.html')
-            except User.DoesNotExist:
-                # Still return success to prevent email enumeration
-                return render(request, 'core/password_reset_done.html')
+            user = User.objects.get(email=email)
+
+            # Generate token and expiration
+            token = Fernet.generate_key().decode()
+            expiration = timezone.now() + timedelta(hours=24)
+
+            user.email_verification_token = token
+            user.email_verification_expiration = expiration
+            user.save()
+
+            # Send password reset email
+            reset_url = request.build_absolute_uri(
+                reverse('core:password_reset_confirm', kwargs={'user_id': user.id, 'token': token})
+            )
+
+            subject = 'Password Reset Request'
+            message = render_to_string('emails/password_reset.html', {
+                'user': user,
+                'reset_link': reset_url
+            })
+
+            send_mail(
+                subject,
+                message,
+                settings.DEFAULT_FROM_EMAIL,
+                [user.email],
+                fail_silently=False
+            )
+
+            return render(request, 'core/password_reset_done.html')
     else:
         form = PasswordResetForm()
     


### PR DESCRIPTION
## Summary
- validate password reset email exists
- update view to rely on form validation
- add regression tests for password reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835e99048483209c56d0f16e6637aa