### PR TITLE
Fix json_script template load error

### DIFF
--- a/WebAppIAM/core/templates/core/enroll_biometrics.html
+++ b/WebAppIAM/core/templates/core/enroll_biometrics.html
@@ -1,4 +1,4 @@
-{% load static json_script %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- drop json_script from template load since it's already available as a built-in filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838038527083209b4af5399bf5dcfc