### PR TITLE
Fix WebAuthn option serialization

### DIFF
--- a/WebAppIAM/core/templates/core/enroll_biometrics.html
+++ b/WebAppIAM/core/templates/core/enroll_biometrics.html
@@ -399,7 +399,7 @@
         faceDone: {{ face_done|yesno:"true,false" }},
         webauthnDone: {{ webauthn_done|yesno:"true,false" }},
         requireBoth: {{ require_both|yesno:"true,false" }},
-        profileRedirect: "{% url 'core:profile_complete' %}",
+        profileRedirect: "{% url 'core:complete_profile' %}",
     };
 
     const optionsEl = document.getElementById('webauthn-options');

--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -36,6 +36,7 @@ from .webauthn_utils import (
     verify_registration_response,
     generate_authentication_options,
     verify_authentication_response,
+    options_to_json,
 )
 from .face_api import verify_face, enroll_face
 from .risk_engine import calculate_risk_score, analyze_behavior_anomaly
@@ -364,7 +365,10 @@ def register_biometrics(request):
         # (existing WebAuthn logic remains the same)
     
     return render(request, 'core/enroll_biometrics.html', {
-        'webauthn_options': generate_registration_options(user) if not user.face_data else None
+        'webauthn_options': (
+            json.loads(options_to_json(generate_registration_options(user)))
+            if not user.face_data else None
+        )
     })
 
 @login_required
@@ -375,7 +379,7 @@ def webauthn_registration_options(request):
     user = request.user
     options = generate_registration_options(user)
     request.session['webauthn_registration_challenge'] = options.challenge
-    return JsonResponse(options.to_dict())
+    return JsonResponse(json.loads(options_to_json(options)))
 
 @login_required
 def webauthn_registration_verify(request):
@@ -610,7 +614,7 @@ def webauthn_authentication_options(request):
     user = User.objects.get(id=user_id)
     options = generate_authentication_options(user)
     request.session['webauthn_authentication_challenge'] = options.challenge
-    return JsonResponse(options.to_dict())
+    return JsonResponse(json.loads(options_to_json(options)))
 
 @csrf_exempt
 @require_http_methods(['POST'])


### PR DESCRIPTION
## Summary
- serialize PublicKeyCredential options safely
- include the library helper in view imports
- fix enrolment page profile redirect

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68838254d2c083209440f1b50aa5f5f4