### PR TITLE
Improve Face API resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# WebAppIAM
+
+## Local Development
+
+Run the server on `localhost:8000` and configure WebAuthn and Face API settings:
+
+```bash
+export WEBAUTHN_RP_ID=localhost
+export WEBAUTHN_EXPECTED_ORIGIN=http://localhost:8000
+export FACE_API_ENABLED=True
+export AZURE_FACE_API_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+export AZURE_FACE_API_KEY=<your-key>
+export AZURE_FACE_PERSON_GROUP_ID=<group-id>
+```
+
+Then start Django:
+
+```bash
+python manage.py runserver localhost:8000
+```
+
+## Production
+
+Set `WEBAUTHN_RP_ID` and `WEBAUTHN_EXPECTED_ORIGIN` to your public domain and
+ensure the site is served over HTTPS.

--- a/WebAppIAM/core/management/commands/faceapi_ping.py
+++ b/WebAppIAM/core/management/commands/faceapi_ping.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from core.face_api import get_face_client
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = "Check connectivity to the Azure Face API"
+
+    def handle(self, *args, **options):
+        try:
+            client = get_face_client()
+            next(client.person_group.list(top=1), None)
+            self.stdout.write(self.style.SUCCESS("Face API reachable"))
+        except Exception as e:
+            logger.exception("Face API ping failed")
+            self.stderr.write(self.style.ERROR(f"Face API check failed: {e}"))
+            return 1

--- a/WebAppIAM/core/test_additional.py
+++ b/WebAppIAM/core/test_additional.py
@@ -72,9 +72,15 @@ class FaceAPITests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="u1", password="p")
 
-    @patch("requests.get", side_effect=requests.RequestException("fail"))
-    def test_check_face_api_status_unavailable(self, mock_get):
+    @patch("core.face_api.get_face_client")
+    def test_check_face_api_status_unavailable(self, mock_client):
+        mock_client.side_effect = Exception("fail")
         self.assertFalse(check_face_api_status())
+
+    @patch("core.face_api.get_face_client")
+    def test_check_face_api_status_success(self, mock_client):
+        mock_client.return_value.person_group.list.return_value = iter([])
+        self.assertTrue(check_face_api_status())
 
     def test_verify_face_disabled(self):
         with self.settings(FACE_API_ENABLED=False):


### PR DESCRIPTION
## Summary
- add cache-backed Face API health check and logging
- support liveness/multi-face detection
- show friendly message on Face API errors
- CLI `faceapi_ping` command
- unit tests for Face API health check and error handling
- add README with local and production setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688388f171f08320a6bcd9d98bbff97e