### PR TITLE
Update WebAuthn docs and fix risk engine API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,8 @@ python manage.py runserver localhost:8000
 ## Production
 
 Set `WEBAUTHN_RP_ID` and `WEBAUTHN_EXPECTED_ORIGIN` to your public domain and
-ensure the site is served over HTTPS.
+ensure the site is served over HTTPS. `WEBAUTHN_RP_ID` **must** contain only the
+host name (no scheme or port). It also needs to match or be a suffix of the
+host serving the page. When developing locally you should use `localhost` and
+not `127.0.0.1`, otherwise WebAuthn will fail with an "invalid domain"
+message.


### PR DESCRIPTION
## Summary
- clarify RP ID requirements for WebAuthn
- restore `load_models` API in risk engine and adjust model usage

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838d1016548320a98ed88cdc04a56b