### PR TITLE
Allow unauthenticated WebAuthn enrollment

### DIFF
--- a/WebAppIAM/WebAppIAM/settings.py
+++ b/WebAppIAM/WebAppIAM/settings.py
@@ -133,6 +133,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Use custom user model
 AUTH_USER_MODEL = 'core.User'
+LOGIN_URL = '/login/'
 
 
 # Email settings (update for production)

--- a/WebAppIAM/core/risk_engine.py
+++ b/WebAppIAM/core/risk_engine.py
@@ -52,6 +52,12 @@ def _load_models():
         _loaded = True
 
 
+def load_models():
+    """Public wrapper returning loaded ML models for testing"""
+    _load_models()
+    return _risk_model, _behavior_model
+
+
 def _assert_schema(n_cols: int, meta: dict):
     expected = meta.get("expected_features", [])
     if not expected:
@@ -68,19 +74,19 @@ def calculate_risk_score(face_match: float,
     Returns probability-like risk score in [0, 1].
     Falls back to rule-based if model unavailable.
     """
-    _load_models()
+    risk_model, _ = load_models()
     feats = np.array([[face_match, float(fingerprint_verified), behavior_anomaly]], dtype=float)
 
-    if _risk_model is None:
+    if risk_model is None:
         logger.warning("Risk model unavailable, falling back to rule-based score.")
         return _rule_risk(face_match, fingerprint_verified, behavior_anomaly)
 
     try:
         _assert_schema(feats.shape[1], _risk_meta)
-        if hasattr(_risk_model, "predict_proba"):
-            return float(_risk_model.predict_proba(feats)[0, 1])
+        if hasattr(risk_model, "predict_proba"):
+            return float(risk_model.predict_proba(feats)[0, 1])
         # Regressor fallback
-        return float(np.clip(_risk_model.predict(feats)[0], 0.0, 1.0))
+        return float(np.clip(risk_model.predict(feats)[0], 0.0, 1.0))
     except Exception as e:
         logger.exception("Risk model inference failed, fallback to rule: %s", e)
         return _rule_risk(face_match, fingerprint_verified, behavior_anomaly)
@@ -91,7 +97,7 @@ def analyze_behavior_anomaly(session) -> float:
     Returns behavior anomaly score in [0, 1].
     Falls back to rule-based if model unavailable.
     """
-    _load_models()
+    _, behavior_model = load_models()
     feats = np.array([[
         getattr(session, 'time_anomaly', 0.0),
         getattr(session, 'device_anomaly', 0.0),
@@ -101,16 +107,16 @@ def analyze_behavior_anomaly(session) -> float:
         getattr(session, 'session_duration', 300.0),
     ]], dtype=float)
 
-    if _behavior_model is None:
+    if behavior_model is None:
         logger.warning("Behavior model unavailable, using rule fallback.")
         return _rule_behavior(session)
 
     try:
         _assert_schema(feats.shape[1], _behavior_meta)
-        if hasattr(_behavior_model, "predict_proba"):
-            return float(_behavior_model.predict_proba(feats)[0, 1])
+        if hasattr(behavior_model, "predict_proba"):
+            return float(behavior_model.predict_proba(feats)[0, 1])
         # Regressor fallback
-        return float(np.clip(_behavior_model.predict(feats)[0], 0.0, 1.0))
+        return float(np.clip(behavior_model.predict(feats)[0], 0.0, 1.0))
     except Exception as e:
         logger.exception("Behavior model inference failed, fallback to rule: %s", e)
         return _rule_behavior(session)


### PR DESCRIPTION
## Summary
- add `get_registration_user` helper for biometric flows
- allow WebAuthn registration without login
- set `LOGIN_URL` so `login_required` redirects correctly
- expose `load_models` wrapper for tests and adjust risk engine

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68839f3069008320aa5d141ee0ed33cf