### PR TITLE
Fix WebAuthn CSRF validation

### DIFF
--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -629,7 +629,7 @@ def webauthn_authentication_options(request):
     
     # Verify the session contains a valid CSRF token
     csrf_token = request.META.get('HTTP_X_CSRFTOKEN')
-    if not csrf_token or not request.session.get('csrf_token') == csrf_token:
+    if not csrf_token or request.session.get('csrftoken') != csrf_token:
         return JsonResponse({'error': 'CSRF validation failed'}, status=403)
     
     user_id = request.session.get('pending_auth_user_id')


### PR DESCRIPTION
## Summary
- fix CSRF token lookup in `webauthn_authentication_options`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688627037ac883209b0f0a66c5018c38