### PR TITLE
Fix WebAuthn CSRF validation

### DIFF
--- a/WebAppIAM/core/test_views_additional.py
+++ b/WebAppIAM/core/test_views_additional.py
@@ -194,6 +194,15 @@ class LoginTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn(b"bad", resp.content)
 
+    @patch("core.views.get_token", return_value="tok")
+    @patch("core.views.render", return_value=HttpResponse("ok"))
+    def test_login_get_sets_csrf_in_session(self, m_render, m_token):
+        request = self.factory.get("/")
+        request.session = {}
+        resp = login(request)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(request.session.get("csrftoken"), "tok")
+
 class ForceCoverageTests(TestCase):
     def test_force_views_lines(self):
         from . import views

--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -11,6 +11,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.http import JsonResponse, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
+from django.middleware.csrf import get_token
 from django.views.decorators.http import require_http_methods, require_POST
 from django.conf import settings
 from django.core.mail import send_mail
@@ -543,6 +544,8 @@ def login(request):
                 messages.error(request, 'Invalid username or password.')
     else:
         form = LoginForm()
+    # Store CSRF token in session for WebAuthn API calls
+    request.session['csrftoken'] = get_token(request)
 
     return render(request, 'core/login.html', {'form': form})
 
@@ -629,7 +632,7 @@ def webauthn_authentication_options(request):
     
     # Verify the session contains a valid CSRF token
     csrf_token = request.META.get('HTTP_X_CSRFTOKEN')
-    if not csrf_token or not request.session.get('csrf_token') == csrf_token:
+    if not csrf_token or request.session.get('csrftoken') != csrf_token:
         return JsonResponse({'error': 'CSRF validation failed'}, status=403)
     
     user_id = request.session.get('pending_auth_user_id')


### PR DESCRIPTION
## Summary
- store the CSRF cookie value in session on login
- test login GET sets the session token

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688627037ac883209b0f0a66c5018c38