### PR TITLE
Fix passkey challenge mismatch

### DIFF
--- a/WebAppIAM/core/templates/core/enroll_biometrics.html
+++ b/WebAppIAM/core/templates/core/enroll_biometrics.html
@@ -759,8 +759,7 @@
     try{
       await getJSON(urls.passkeyOptions, { method:'POST', headers:{'X-CSRFToken':CSRF} });
     }catch{
-      try{ await getJSON(urls.passkeyOptions); }
-      catch { notes.push('Passkey options endpoint unreachable'); }
+      notes.push('Passkey options endpoint unreachable');
     }
 
     if (notes.length === 0){
@@ -957,12 +956,7 @@
   // ---------- Passkey flow ----------
   const passkey = {
     async options(){
-      // Prefer POST with CSRF, fallback to GET for setups that expect GET
-      try{
-        return await getJSON(urls.passkeyOptions, { method:'POST', headers:{'X-CSRFToken': CSRF} });
-      }catch{
-        return await getJSON(urls.passkeyOptions);
-      }
+      return await getJSON(urls.passkeyOptions, { method:'POST', headers:{'X-CSRFToken': CSRF} });
     },
     
     async create(){

--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -379,12 +379,20 @@ def register_biometrics(request):
         # Handle WebAuthn registration
         # (existing WebAuthn logic remains the same)
     
-    return render(request, 'core/enroll_biometrics.html', {
-        'webauthn_options': (
-            json.loads(options_to_json(generate_registration_options(user)))
-            if not user.face_data else None
+    options = None
+    if not user.face_data:
+        options = generate_registration_options(user)
+        request.session['webauthn_registration_challenge'] = bytes_to_base64url(
+            options.challenge
         )
-    })
+
+    return render(
+        request,
+        'core/enroll_biometrics.html',
+        {
+            'webauthn_options': json.loads(options_to_json(options)) if options else None
+        },
+    )
 
 def webauthn_registration_options(request):
     if not settings.WEBAUTHN_ENABLED:


### PR DESCRIPTION
## Summary
- track registration challenge when rendering biometric enrollment page
- fetch passkey options via POST only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688643fafd548320abc62424166991cd