### PR TITLE
Fix admin checks and model path

### DIFF
--- a/WebAppIAM/core/risk_engine.py
+++ b/WebAppIAM/core/risk_engine.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 ML_MODELS_DIR = getattr(
     settings,
     "ML_MODELS_DIR",
-    os.path.abspath(os.path.join(settings.BASE_DIR, "ml_pipeline", "models", "production"))
+    os.path.abspath(
+        os.path.join(settings.BASE_DIR, "..", "ml_pipeline", "models", "production")
+    ),
 )
 
 # Lazy globals

--- a/WebAppIAM/core/urls.py
+++ b/WebAppIAM/core/urls.py
@@ -33,9 +33,9 @@ urlpatterns = [
     path('admin/dashboard/', views.admin_dashboard, name='admin_dashboard'),
 
     # Admin Management URLs
-    path('admin/users/activate/<int:user_id>/', views.activate_user, name='activate_user'),
-    path('admin/users/lock/<int:user_id>/', views.lock_user, name='lock_user'),
-    path('admin/users/unlock/<int:user_id>/', views.unlock_user, name='unlock_user'),
+    path('admin/users/activate/<int:user_id>/', views.activate_user, name='admin_activate_user'),
+    path('admin/users/lock/<int:user_id>/', views.lock_user, name='admin_lock_user'),
+    path('admin/users/unlock/<int:user_id>/', views.unlock_user, name='admin_unlock_user'),
 
 
     # Profile Management

--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -238,8 +238,10 @@ def create_new_device_notification(user, session, device_info):
 
 # --- Helper functions ---
 def is_admin(user):
-    """Check if the user is an administrator"""
-    return user.is_staff and user.is_superuser
+    """Check if the user is an administrator."""
+    if not getattr(user, "is_authenticated", False):
+        return False
+    return user.is_superuser or getattr(user, "role", None) == "ADMIN"
 
 # --- Security Logging ---
 def log_security_event(request, event_type, details, success=False):


### PR DESCRIPTION
## Summary
- correct is_admin helper to work with custom user role
- point risk engine to the correct ML model directory
- align admin URL names with templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868835dcb483209e241d3eb80ad872