### PR TITLE
Fix admin dashboard URL resolution

### DIFF
--- a/WebAppIAM/WebAppIAM/urls.py
+++ b/WebAppIAM/WebAppIAM/urls.py
@@ -19,6 +19,8 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    # Include application URLs before the built-in admin to allow custom
+    # paths like ``admin/dashboard/`` to resolve correctly.
     path('', include('core.urls', namespace='core')),
+    path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
## Summary
- reorder URL patterns so custom `admin/*` routes resolve before the built-in admin

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887d00db9e88320858178ca15e9b531