### PR TITLE
Fix admin users reverse lookup

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -347,7 +347,7 @@
                 </span>
             </a>
 
-            <a href="" data-section="users">
+            <a href="{% url 'core:admin_users' %}" data-section="users">
                 <span class="left">
                     <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
                     Users

--- a/WebAppIAM/core/urls.py
+++ b/WebAppIAM/core/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     # Dashboard URLs
     path('staff/dashboard/', views.staff_dashboard, name='staff_dashboard'),
     path('admin/dashboard/', views.admin_dashboard, name='admin_dashboard'),
+    path('admin/users/', views.admin_users, name='admin_users'),
 
     # Admin Management URLs
     path('admin/users/activate/<int:user_id>/', views.activate_user, name='admin_activate_user'),

--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -997,6 +997,23 @@ def admin_dashboard(request):
     
     return render(request, 'core/admin_dashboard.html', context)
 
+
+@login_required
+@user_passes_test(is_admin)
+def admin_users(request):
+    """List all users for the admin dashboard."""
+    users = User.objects.all().select_related('profile')
+    pending_users = User.objects.filter(is_active=False)
+    return render(
+        request,
+        'core/admin_dashboard.html',
+        {
+            'users': users,
+            'pending_users': pending_users,
+            'show_user_management': True,
+        },
+    )
+
 # --- Document Vault Views ---
 @login_required
 def document_list(request):


### PR DESCRIPTION
## Summary
- add `admin_users` view for listing users
- wire the view in URLs
- link to the users page from the admin dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d8daccbc8320a7ab95dc21ba9588