### PR TITLE
Fix WebAuthn authentication options

### DIFF
--- a/WebAppIAM/core/webauthn_utils.py
+++ b/WebAppIAM/core/webauthn_utils.py
@@ -24,6 +24,7 @@ from webauthn.helpers.structs import (
     AuthenticationCredential,
     PublicKeyCredentialDescriptor,
     PublicKeyCredentialType,
+    AuthenticatorTransport,
 )
 from django.conf import settings
 
@@ -68,7 +69,7 @@ def generate_authentication_options(user):
         PublicKeyCredentialDescriptor(
             id=base64url_to_bytes(cred.credential_id),
             type=PublicKeyCredentialType.PUBLIC_KEY,
-            transports=["internal"],
+            transports=[AuthenticatorTransport.INTERNAL],
         )
         for cred in user.webauthn_credentials.all()
     ]


### PR DESCRIPTION
## Summary
- ensure transports for `PublicKeyCredentialDescriptor` use enum `AuthenticatorTransport`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e4fb2f188320917446301ff699f0