### PR TITLE
Fix WebAuthn response parsing

### DIFF
--- a/WebAppIAM/core/webauthn_utils.py
+++ b/WebAppIAM/core/webauthn_utils.py
@@ -50,7 +50,7 @@ def verify_registration_response(user, data, expected_challenge):
     verification = wa_verify_registration_response(
         credential=RegistrationCredential(
             id=credential.id,
-            raw_id=base64url_to_bytes(credential.raw_id),
+            raw_id=credential.raw_id,
             response=credential.response,
             type=credential.type,
             client_extension_results=credential.client_extension_results,
@@ -90,7 +90,7 @@ def verify_authentication_response(user, data, expected_challenge):
     verification = wa_verify_authentication_response(
         credential=AuthenticationCredential(
             id=credential.id,
-            raw_id=base64url_to_bytes(credential.raw_id),
+            raw_id=credential.raw_id,
             response=credential.response,
             type=credential.type,
             client_extension_results=credential.client_extension_results,


### PR DESCRIPTION
## Summary
- avoid double base64 decoding of WebAuthn credential data

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6887e7ee69a48320bf15a1d18f8a1e79