### PR TITLE
Fix crash when user lacks behavior profile

### DIFF
--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -811,7 +811,7 @@ def finalize_authentication(request, session):
     device_info = get_device_info(request)
     
     # Behavior analysis
-    behavior_profile = user.behavior_profile
+    behavior_profile, _ = UserBehaviorProfile.objects.get_or_create(user=user)
     current_time = timezone.now().time()
     time_anomaly = 0
     device_anomaly = 0


### PR DESCRIPTION
## Summary
- ensure finalize_authentication creates a UserBehaviorProfile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f0e82f048320ade56f8a11ac893c