### PR TITLE
Fix WebAuthn redirect to dashboards

### DIFF
--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -793,7 +793,7 @@ def webauthn_authentication_verify(request):
             dashboard_url = 'admin_dashboard' if user.role == 'ADMIN' else 'staff_dashboard'
             return JsonResponse({
                 'status': 'success',
-                'redirect': reverse(f'core:{dashboard_url}')
+                'next': reverse(f'core:{dashboard_url}')
             })
         else:
             return JsonResponse({


### PR DESCRIPTION
## Summary
- correct key in WebAuthn verify response so the login page can redirect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f82266308320b652e6fdea7955e2