### PR TITLE
Fix dashboard context and notification dismissal

### DIFF
--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -577,6 +577,7 @@
                             {% if n.action_required %}
                             <form method="post" action="{% url 'core:dismiss_device_notification' n.id %}" style="margin-top: 8px;">
                                 {% csrf_token %}
+                                <input type="hidden" name="next" value="{{ request.path }}#notifications">
                                 <button class="btn btn-outline" type="submit">Dismiss</button>
                             </form>
                             {% endif %}


### PR DESCRIPTION
## Summary
- reuse dashboard view for staff dashboard to include sessions, documents, and devices
- persist profile preferences like `show_face_match` and `auto_logout`
- allow dismissing notifications without leaving the page
- keep dismissal redirect using `next` hidden field

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688886cec94c8320b941db75d12d3848