### PR TITLE
Update document upload departments

### DIFF
--- a/WebAppIAM/core/forms.py
+++ b/WebAppIAM/core/forms.py
@@ -68,6 +68,11 @@ class CustomPasswordChangeForm(PasswordChangeForm):
 
 class DocumentUploadForm(forms.ModelForm):
     file = forms.FileField(label='File to upload')
+    # Present predefined department choices instead of a free text field
+    department = forms.ChoiceField(
+        choices=UserProfile.DEPT_CHOICES,
+        required=False
+    )
     
     class Meta:
         model = Document


### PR DESCRIPTION
## Summary
- add department choices to the document upload form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ad51160c8320ab2e15bf98aa7b2d