### PR TITLE
Fix profile update fields and show avatars

### DIFF
--- a/WebAppIAM/WebAppIAM/settings.py
+++ b/WebAppIAM/WebAppIAM/settings.py
@@ -125,6 +125,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
 STATIC_URL = 'static/'
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

--- a/WebAppIAM/WebAppIAM/urls.py
+++ b/WebAppIAM/WebAppIAM/urls.py
@@ -17,6 +17,8 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     # Include application URLs before the built-in admin to allow custom
@@ -24,3 +26,6 @@ urlpatterns = [
     path('', include('core.urls', namespace='core')),
     path('admin/', admin.site.urls),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/WebAppIAM/core/forms.py
+++ b/WebAppIAM/core/forms.py
@@ -119,8 +119,8 @@ class ProfileUpdateForm(forms.ModelForm):
     
     class Meta:
         model = UserProfile
-        fields = ['department', 'position', 'phone', 'profile_picture', 
-                  'show_risk_alerts', 'show_face_match', 'auto_logout', 'receive_email_alerts']
+        fields = ['department', 'position', 'phone', 'profile_picture',
+                  'show_risk_alerts', 'auto_logout', 'receive_email_alerts']
         widgets = {
             'position': forms.TextInput(attrs={'class': 'form-control'}),
             'phone': forms.TextInput(attrs={'class': 'form-control'}),

--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -143,6 +143,13 @@
             animation: shimmer 2.5s infinite, fadeSlideIn 320ms ease forwards;
             opacity: 0;
         }
+        .avatar{
+            width:40px;
+            height:40px;
+            border-radius:50%;
+            object-fit:cover;
+            margin-left:auto;
+        }
         @keyframes shimmer{
             0%{ background-position: 0% 50%; }
             100%{ background-position: 200% 50%; }
@@ -416,6 +423,9 @@
             <h1 class="hello">
                 Hello, {{ request.user.first_name|default:request.user.username }} 👋
             </h1>
+            {% if request.user.profile.profile_picture %}
+            <img class="avatar" src="{{ request.user.profile.profile_picture.url }}" alt="Profile picture">
+            {% endif %}
         </header>
 
         <main class="content">
@@ -761,6 +771,7 @@
 
     // On load: show stored or hash target or dashboard
     let initial = 'dashboard';
+    if ({{ show_profile_settings|yesno:"true,false" }}) initial = 'profile';
     try {
         initial = localStorage.getItem('active-section') || initial;
     } catch(e){}

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -144,6 +144,13 @@
             animation: shimmer 2.5s infinite, fadeSlideIn 320ms ease forwards;
             opacity: 0;
         }
+        .avatar{
+            width:40px;
+            height:40px;
+            border-radius:50%;
+            object-fit:cover;
+            margin-left:auto;
+        }
         @keyframes shimmer{
             0%{ background-position: 0% 50%; }
             100%{ background-position: 200% 50%; }
@@ -436,6 +443,9 @@
             <h1 class="hello">
                 Hello, {% firstof request.user.first_name request.user.username %} 👋
             </h1>
+            {% if request.user.profile.profile_picture %}
+            <img class="avatar" src="{{ request.user.profile.profile_picture.url }}" alt="Profile picture">
+            {% endif %}
         </header>
 
         <main class="content">
@@ -642,6 +652,7 @@
     });
 
     let initial = 'dashboard';
+    if ({{ show_profile_settings|yesno:"true,false" }}) initial = 'profile';
     try {
         initial = localStorage.getItem('staff-active-section') || initial;
     } catch(e){}

--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -1245,7 +1245,6 @@ def profile_settings(request):
         'email': user.email,
         'phone': profile.phone,
         'show_risk_alerts': profile.show_risk_alerts,
-        'show_face_match': profile.show_face_match,
         'auto_logout': profile.auto_logout,
         'receive_email_alerts': profile.receive_email_alerts
     })
@@ -1280,7 +1279,6 @@ def update_profile(request):
         profile.position = form.cleaned_data['position']
         profile.phone = form.cleaned_data.get('phone')
         profile.show_risk_alerts = form.cleaned_data['show_risk_alerts']
-        profile.show_face_match = form.cleaned_data['show_face_match']
         profile.auto_logout = form.cleaned_data['auto_logout']
         profile.receive_email_alerts = form.cleaned_data['receive_email_alerts']
 
@@ -1306,7 +1304,10 @@ def update_profile(request):
             send_mail(subject, message, settings.DEFAULT_FROM_EMAIL,
                       [form.cleaned_data['email']], fail_silently=False)
 
+
             messages.info(request, f"Verification email sent to {form.cleaned_data['email']}. Please verify to complete the email change.")
+
+        user.save(update_fields=['first_name', 'last_name'])
 
         if 'profile_picture' in request.FILES:
             profile.profile_picture = request.FILES['profile_picture']


### PR DESCRIPTION
## Summary
- ensure profile updates save phone and picture
- remove obsolete 'Show face match' option
- show profile avatar in dashboard headers
- add MEDIA settings and serve media files
- open profile section automatically when requested

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890212e388832085cf16d56daa88bf