### PR TITLE
Add password visibility toggle in profile forms

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -684,6 +684,28 @@
                         {{ password_form.as_p }}
                         <button class="btn" type="submit">Change Password</button>
                     </form>
+                    <script>
+                    (function(){
+                        const form = document.querySelector('section[data-view="profile"] form[action*="change_password"]');
+                        if(form){
+                            form.querySelectorAll('input[type="password"]').forEach(function(input){
+                                const btn = document.createElement('button');
+                                btn.type = 'button';
+                                btn.className = 'toggle-visibility';
+                                btn.setAttribute('aria-label','Toggle password visibility');
+                                btn.innerHTML = `<svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg>`;
+                                input.insertAdjacentElement('afterend', btn);
+                                btn.addEventListener('click', function(){
+                                    const visible = input.type === 'text';
+                                    input.type = visible ? 'password' : 'text';
+                                    btn.innerHTML = visible
+                                        ? `<svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg>`
+                                        : `<svg viewBox="0 0 24 24"><path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a21.77 21.77 0 0 1 5.06-6.94M9.9 4.24A10.94 10.94 0 0 1 12 4c7 0 11 7 11 7a21.77 21.77 0 0 1-3.17 4.15M1 1l22 22"></path></svg>`;
+                                });
+                            });
+                        }
+                    })();
+                    </script>
                 </div>
             </section>
 
@@ -778,22 +800,6 @@
     if (location.hash) initial = location.hash.slice(1);
     activate(initial);
 
-    // Show/hide password fields in change password form
-    document.querySelectorAll('form[action*="change_password"] input[type="password"]').forEach(function(input){
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'toggle-visibility';
-        btn.setAttribute('aria-label', 'Toggle password visibility');
-        btn.innerHTML = `<svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg>`;
-        input.insertAdjacentElement('afterend', btn);
-        btn.addEventListener('click', function(){
-            const visible = input.type === 'text';
-            input.type = visible ? 'password' : 'text';
-            btn.innerHTML = visible
-                ? `<svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg>`
-                : `<svg viewBox="0 0 24 24"><path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a21.77 21.77 0 0 1 5.06-6.94M9.9 4.24A10.94 10.94 0 0 1 12 4c7 0 11 7 11 7a21.77 21.77 0 0 1-3.17 4.15M1 1l22 22"></path></svg>`;
-        });
-    });
 })();
 </script>
 </body>

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -574,6 +574,28 @@
                         {{ password_form.as_p }}
                         <button class="btn" type="submit">Change Password</button>
                     </form>
+                    <script>
+                    (function(){
+                        const form = document.querySelector('section[data-view="profile"] form[action*="change_password"]');
+                        if(form){
+                            form.querySelectorAll('input[type="password"]').forEach(function(input){
+                                const btn = document.createElement('button');
+                                btn.type = 'button';
+                                btn.className = 'toggle-visibility';
+                                btn.setAttribute('aria-label','Toggle password visibility');
+                                btn.innerHTML = `<svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg>`;
+                                input.insertAdjacentElement('afterend', btn);
+                                btn.addEventListener('click', function(){
+                                    const visible = input.type === 'text';
+                                    input.type = visible ? 'password' : 'text';
+                                    btn.innerHTML = visible
+                                        ? `<svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg>`
+                                        : `<svg viewBox="0 0 24 24"><path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a21.77 21.77 0 0 1 5.06-6.94M9.9 4.24A10.94 10.94 0 0 1 12 4c7 0 11 7 11 7a21.77 21.77 0 0 1-3.17 4.15M1 1l22 22"></path></svg>`;
+                                });
+                            });
+                        }
+                    })();
+                    </script>
                 </div>
             </section>
 
@@ -659,22 +681,6 @@
     if (location.hash) initial = location.hash.slice(1);
     activate(initial);
 
-    // Show/hide password fields in change password form
-    document.querySelectorAll('form[action*="change_password"] input[type="password"]').forEach(function(input){
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'toggle-visibility';
-        btn.setAttribute('aria-label', 'Toggle password visibility');
-        btn.innerHTML = `<svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg>`;
-        input.insertAdjacentElement('afterend', btn);
-        btn.addEventListener('click', function(){
-            const visible = input.type === 'text';
-            input.type = visible ? 'password' : 'text';
-            btn.innerHTML = visible
-                ? `<svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg>`
-                : `<svg viewBox="0 0 24 24"><path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a21.77 21.77 0 0 1 5.06-6.94M9.9 4.24A10.94 10.94 0 0 1 12 4c7 0 11 7 11 7a21.77 21.77 0 0 1-3.17 4.15M1 1l22 22"></path></svg>`;
-        });
-    });
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add visibility toggle script for change-password fields in profile section
- remove old password visibility toggle logic

## Testing
- `python manage.py test`
- `python ../scripts/check_static_templates.py`


------
https://chatgpt.com/codex/tasks/task_e_68890692c1608320b702d3b2db177dc6