### PR TITLE
Fix admin profile form and add small upload button

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -284,6 +284,7 @@
         }
         .btn-outline:hover { background: var(--surface-2); }
         .btn-danger { background: var(--danger); }
+        .btn-sm { padding: 4px 10px; font-size: 0.875rem; }
 
         /* Alerts */
         .alert {
@@ -298,6 +299,24 @@
             border-color: rgba(251, 191, 36, 0.2);
             color: #fbbf24;
         }
+
+        /* Django messages list */
+        ul.messages {
+            list-style: none;
+            padding: 0;
+            margin: 0 0 16px;
+        }
+        ul.messages li {
+            margin-bottom: 8px;
+            padding: 10px 12px;
+            border-radius: 8px;
+            background: var(--surface-2);
+            color: var(--text);
+        }
+        ul.messages li.success { border-left: 3px solid var(--success); }
+        ul.messages li.error { border-left: 3px solid var(--danger); }
+        ul.messages li.warning { border-left: 3px solid var(--warning); }
+        ul.messages li.info { border-left: 3px solid var(--primary); }
 
         /* Section switching */
         .section {
@@ -601,7 +620,7 @@
                     <form method="post" action="{% url 'core:document_upload' %}" enctype="multipart/form-data">
                         {% csrf_token %}
                         {{ form.as_p }}
-                        <button class="btn" type="submit">Upload</button>
+                        <button class="btn btn-sm" type="submit">Upload</button>
                     </form>
                 </div>
             </section>
@@ -672,7 +691,12 @@
             <section class="section" data-view="profile">
                 <div class="card">
                     <h2>Profile Settings</h2>
-                    <form method="post" enctype="multipart/form-data">
+                    {% if messages %}
+                    <ul class="messages">
+                        {% for m in messages %}<li class="{{ m.tags }}">{{ m }}</li>{% endfor %}
+                    </ul>
+                    {% endif %}
+                    <form method="post" action="{% url 'core:update_profile' %}" enctype="multipart/form-data">
                         {% csrf_token %}
                         {{ profile_form.as_p }}
                         <button class="btn" type="submit">Update Profile</button>


### PR DESCRIPTION
## Summary
- wire up Admin profile update form to proper URL
- show Django messages on Admin dashboard
- add small button style for document upload
- include `.btn-sm` CSS for Admin dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891cc840fc8320a3221e463ca73775