### PR TITLE
Fix email configuration for development

### DIFF
--- a/WebAppIAM/WebAppIAM/settings.py
+++ b/WebAppIAM/WebAppIAM/settings.py
@@ -138,16 +138,25 @@ AUTH_USER_MODEL = 'core.User'
 LOGIN_URL = '/login/'
 
 
-# Email settings (update for production)
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp-mail.outlook.com'
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-EMAIL_HOST_USER = 'webappIAM@outlook.com'
-EMAIL_HOST_PASSWORD = 'testcase@123456'
-EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', 'webappIAM@outlook.com')
-EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', 'thenewpasswordisgreat!@##')
-DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER)
+# Email settings
+#
+# Default to the console backend in development so that the application
+# doesn't attempt to connect to the external SMTP server when running
+# locally or in restricted environments.  The backend can be overridden
+# via the ``EMAIL_BACKEND`` environment variable for production.
+# ``EMAIL_HOST_USER`` and ``EMAIL_HOST_PASSWORD`` can also be supplied via
+# environment variables.
+EMAIL_BACKEND = os.environ.get(
+    "EMAIL_BACKEND",
+    "django.core.mail.backends.console.EmailBackend" if DEBUG else "django.core.mail.backends.smtp.EmailBackend",
+)
+EMAIL_HOST = os.environ.get("EMAIL_HOST", "smtp-mail.outlook.com")
+EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "587"))
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "True") == "True"
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "webappIAM@outlook.com")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "thenewpasswordisgreat!@##")
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)
+EMAIL_TIMEOUT = int(os.environ.get("EMAIL_TIMEOUT", "10"))
 
 # Face recognition configuration (DeepFace)
 FACE_API_ENABLED = True


### PR DESCRIPTION
## Summary
- make email backend configurable via env vars
- default to console backend for development

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889296266ac8320bbc3cbbeb83be389