### PR TITLE
Fix admin user management

### DIFF
--- a/WebAppIAM/core/models.py
+++ b/WebAppIAM/core/models.py
@@ -79,6 +79,19 @@ class User(AbstractUser):
             login_time__gte=timezone.now() - timezone.timedelta(hours=24)
         ).exists()
 
+    @property
+    def biometric_enrolled(self):
+        """Return True if the user has any biometric data enrolled."""
+        return self.has_biometrics
+
+    @property
+    def is_locked(self):
+        """Return True if the user account is temporarily locked out."""
+        if self.failed_login_attempts >= settings.MAX_FAILED_LOGINS:
+            if self.last_failed_login and timezone.now() < self.last_failed_login + timezone.timedelta(minutes=settings.ACCOUNT_LOCKOUT_MINUTES):
+                return True
+        return False
+
     def require_reenrollment(self):
         """Force user to re-enroll their biometrics"""
         self.force_reenroll = True

--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -971,6 +971,7 @@
 
     // On load: show stored or hash target or dashboard
     let initial = 'dashboard';
+    if ({{ show_user_management|yesno:"true,false" }}) initial = 'users';
     if ({{ show_profile_settings|yesno:"true,false" }}) initial = 'profile';
     try {
         initial = localStorage.getItem('active-section') || initial;


### PR DESCRIPTION
## Summary
- add biometric status and lock checks to `User`
- activate user section when requested on the admin dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c4c9f81083209931103ead2d339b