### PR TITLE
Add staff document download button

### DIFF
--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -612,9 +612,7 @@
                             <td>{{ doc.title }}</td>
                             <td>{{ doc.version }}</td>
                             <td>
-                                {% if doc.can_download %}
                                 <a class="btn btn-outline" href="{% url 'core:document_download' doc.id %}">Download</a>
-                                {% endif %}
                             </td>
                         </tr>
                         {% empty %}


### PR DESCRIPTION
## Summary
- always show download button in staff documents list

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688bc372c08c832084b293d946d3be0f