### PR TITLE
Replace session metric with device count

### DIFF
--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -564,8 +564,8 @@
             <section class="section active" data-view="dashboard">
                 <div class="cards-grid">
                     <div class="card metric">
-                        <span class="label">Active Sessions</span>
-                        <span class="value">{{ sessions|length }}</span>
+                        <span class="label">Trusted Devices</span>
+                        <span class="value">{{ devices|length }}</span>
                     </div>
                     <div class="card metric">
                         <span class="label">Unread Notifications</span>


### PR DESCRIPTION
## Summary
- tweak staff dashboard metrics to display total trusted devices instead of active sessions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bca9ec37c8320be09a051638706e6