### PR TITLE
Display document department

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -721,12 +721,13 @@
                     <h2>Documents</h2>
                     <table>
                         <thead>
-                        <tr><th>Title</th><th>Version</th><th>Actions</th></tr>
+                        <tr><th>Title</th><th>Department</th><th>Version</th><th>Actions</th></tr>
                         </thead>
                         <tbody>
                         {% for doc in documents %}
                         <tr>
                             <td>{{ doc.title }}</td>
+                            <td>{{ doc.department }}</td>
                             <td>{{ doc.version }}</td>
                             <td>
                                 <a class="btn btn-outline" href="{% url 'core:document_download' doc.id %}">Download</a>

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -604,12 +604,13 @@
                     <h2>Documents</h2>
                     <table>
                         <thead>
-                        <tr><th>Title</th><th>Version</th><th>Actions</th></tr>
+                        <tr><th>Title</th><th>Department</th><th>Version</th><th>Actions</th></tr>
                         </thead>
                         <tbody>
                         {% for doc in documents %}
                         <tr>
                             <td>{{ doc.title }}</td>
+                            <td>{{ doc.department }}</td>
                             <td>{{ doc.version }}</td>
                             <td>
                                 <a class="btn btn-outline" href="{% url 'core:document_download' doc.id %}">Download</a>


### PR DESCRIPTION
## Summary
- show the document department column in the admin and staff dashboard

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688bcdae82608320888dc245f330482c