### PR TITLE
Add admin document editing

### DIFF
--- a/WebAppIAM/core/forms.py
+++ b/WebAppIAM/core/forms.py
@@ -83,6 +83,22 @@ class DocumentUploadForm(forms.ModelForm):
         # This is just for the form validation
         return super().save(commit=commit)
 
+
+class DocumentEditForm(forms.ModelForm):
+    """Form used to edit an existing document."""
+    file = forms.FileField(label="New file", required=False)
+    department = forms.ChoiceField(
+        choices=UserProfile.DEPT_CHOICES,
+        required=False,
+    )
+
+    class Meta:
+        model = Document
+        fields = ["title", "description", "access_level", "department"]
+
+    def save(self, commit=True):
+        return super().save(commit=commit)
+
 class ProfileCompletionForm(forms.ModelForm):
     first_name = forms.CharField(
         max_length=30,

--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -457,6 +457,15 @@
             transform: rotate(45deg);
         }
 
+        /* Modal for document editing */
+        .modal { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; background: rgba(0,0,0,.7); backdrop-filter: blur(8px); z-index: 1000; opacity: 0; transition: opacity .3s; }
+        .modal.open { display: flex; opacity: 1; }
+        .modal-card { width: min(500px, 92vw); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); padding: 20px; position: relative; transform: scale(.95); transition: transform .3s; }
+        .modal.open .modal-card { transform: scale(1); }
+        .modal-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
+        .modal-title { font-size: 18px; font-weight: 600; }
+        .modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+
         /* Mobile */
         @media (max-width: 960px) {
             .layout {
@@ -634,6 +643,24 @@
                 </div>
             </section>
 
+            {% if edit_form %}
+            <div id="edit-modal" class="modal{% if show_document_edit %} open{% endif %}" aria-hidden="true">
+                <div class="modal-card">
+                    <div class="modal-header">
+                        <h2 class="modal-title">Edit Document</h2>
+                    </div>
+                    <form method="post" action="{% url 'core:document_edit' edit_document.id %}" enctype="multipart/form-data">
+                        {% csrf_token %}
+                        {{ edit_form.as_p }}
+                        <div class="modal-actions">
+                            <button class="btn" type="submit">Save</button>
+                            <a href="{% url 'core:document_list' %}" class="btn btn-outline">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            {% endif %}
+
             <!-- USERS -->
             <section class="section" data-view="users">
                 <div class="card">
@@ -731,6 +758,7 @@
                             <td>{{ doc.version }}</td>
                             <td>
                                 <a class="btn btn-outline" href="{% url 'core:document_download' doc.id %}">Download</a>
+                                <a class="btn btn-outline" href="{% url 'core:document_edit' doc.id %}">Edit</a>
                             </td>
                         </tr>
                         {% empty %}
@@ -1041,8 +1069,10 @@
     let initial = 'dashboard';
     const showUserManagement = JSON.parse("{{ show_user_management|yesno:'true,false'|lower }}".replace(/'/g, '"'));
     const showProfileSettings = JSON.parse("{{ show_profile_settings|yesno:'true,false'|lower }}".replace(/'/g, '"'));
+    const showDocumentEdit = JSON.parse("{{ show_document_edit|yesno:'true,false'|lower }}".replace(/'/g, '"'));
     if (showUserManagement) initial = 'users';
     if (showProfileSettings) initial = 'profile';
+    if (showDocumentEdit) initial = 'documents';
     try {
         initial = localStorage.getItem('active-section') || initial;
     } catch(e){}

--- a/WebAppIAM/core/test_document_edit.py
+++ b/WebAppIAM/core/test_document_edit.py
@@ -1,0 +1,46 @@
+import os
+import django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'WebAppIAM.settings')
+django.setup()
+
+from django.test import TestCase, Client
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from .models import User, Document
+
+
+class DocumentEditTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.admin = User.objects.create_user(username="admin", password="pass", role="ADMIN")
+        self.client.force_login(self.admin)
+        self.doc = Document.objects.create(
+            title="Doc",
+            description="",
+            access_level="PRIVATE",
+            encrypted_file=b"a",
+            original_filename="a.txt",
+            file_type="text/plain",
+            file_size=1,
+            encryption_key=b"k",
+            uploaded_by=self.admin,
+        )
+
+    def test_edit_creates_new_version(self):
+        new_file = SimpleUploadedFile("b.txt", b"b", content_type="text/plain")
+        with self.settings(ALLOWED_HOSTS=['testserver']):
+            resp = self.client.post(
+                reverse('core:document_edit', args=[self.doc.id]),
+                {
+                    'title': 'Doc',
+                    'description': '',
+                    'access_level': 'PRIVATE',
+                    'department': '',
+                    'file': new_file,
+                },
+            )
+        self.assertEqual(resp.status_code, 302)
+        new_doc = Document.objects.get(title="Doc", deleted=False)
+        self.assertEqual(new_doc.version, self.doc.version + 1)
+        self.assertTrue(Document.objects.filter(id=self.doc.id, deleted=True).exists())

--- a/WebAppIAM/core/urls.py
+++ b/WebAppIAM/core/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
     path('documents/', views.document_list, name='document_list'),
     path('documents/upload/', views.document_upload, name='document_upload'),
     path('documents/download/<int:doc_id>/', views.document_download, name='document_download'),
+    path('documents/edit/<int:doc_id>/', views.document_edit, name='document_edit'),
     path('documents/purge/<int:doc_id>/', views.purge_document, name='purge_document'),
     path('documents/validate_checksum/<int:doc_id>/', views.validate_checksum, name='validate_checksum'),
 


### PR DESCRIPTION
## Summary
- allow admins to edit documents via new form and view
- show edit link in admin dashboard
- include edit endpoint in URL config
- create document edit template
- test versioning after edit
- integrate document edit modal into dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bd53af92c8320adbdc97e2857ccb9