### PR TITLE
Restrict device listing to current user

### DIFF
--- a/WebAppIAM/core/tests.py
+++ b/WebAppIAM/core/tests.py
@@ -191,10 +191,10 @@ class DeviceViewTests(TestCase):
         devices = list(response.context["devices"])
         self.assertEqual(devices, [self.staff_fp])
 
-    def test_admin_sees_all_devices(self):
+    def test_admin_only_sees_own_devices(self):
         self.client.force_login(self.admin)
         response = self.client.get(reverse("core:manage_devices"))
-        device_ids = {d.id for d in response.context["devices"]}
-        self.assertEqual(device_ids, {self.admin_fp.id, self.staff_fp.id})
+        devices = list(response.context["devices"])
+        self.assertEqual(devices, [self.admin_fp])
 
 


### PR DESCRIPTION
## Summary
- limit device dashboard queries to the requesting user
- update device management views to only allow actions on the user's own devices
- fix tests accordingly

## Testing
- `python WebAppIAM/manage.py test core -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688c7a36259083208c949346a2810ab4