### PR TITLE
Fix notifications display

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -1066,7 +1066,7 @@
     });
 
     // On load: show stored or hash target or dashboard
-    let initial = 'dashboard';
+    let initial = '{{ active_tab|default:"dashboard" }}';
     const showUserManagement = JSON.parse("{{ show_user_management|yesno:'true,false'|lower }}".replace(/'/g, '"'));
     const showProfileSettings = JSON.parse("{{ show_profile_settings|yesno:'true,false'|lower }}".replace(/'/g, '"'));
     const showDocumentEdit = JSON.parse("{{ show_document_edit|yesno:'true,false'|lower }}".replace(/'/g, '"'));

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -870,7 +870,7 @@
         }
     }
 
-    let initial = 'dashboard';
+    let initial = '{{ active_tab|default:"dashboard" }}';
     const showProfileSettings = JSON.parse("{{ show_profile_settings|yesno:'true,false'|lower }}".replace(/'/g, '"'));
     if (showProfileSettings) initial = 'profile';
     try {

--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -1535,7 +1535,8 @@ def notifications_view(request):
 
     context = {
         'notifications': notifications,
-        'show_notifications': True
+        'show_notifications': True,
+        'active_tab': 'notifications',
     }
 
     if request.user.role == 'ADMIN':


### PR DESCRIPTION
## Summary
- load notifications section by default when visiting `/notifications/`
- inject `active_tab` state into dashboard templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c848d019883209d1c3e5183f8be4a