### PR TITLE
Fix admin dashboard audit log section

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -834,22 +834,35 @@
                         </tbody>
                     </table>
                 </div>
+            </section>
+
+            <!-- AUDIT LOGS -->
+            <section class="section" data-view="audit">
+                <div class="card mt-24">
+                    <h3>Audit Logs</h3>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>User</th>
+                                    <th>Action</th>
+                                    <th>Timestamp</th>
+                                    <th>IP Address</th>
+                                </tr>
                             </thead>
                             <tbody>
-                            {% for log in audit_logs %}
-                                <tr>
-                                    <td>{{ log.user }}</td>
-                                    <td>{{ log.action }}</td>
-                                    <td>{{ log.timestamp }}</td>
-                                    <td>{{ log.ip_address }}</td>
-                                </tr>
-                            {% endfor %}
+                                {% for log in audit_logs %}
+                                    <tr>
+                                        <td>{{ log.user }}</td>
+                                        <td>{{ log.action }}</td>
+                                        <td>{{ log.timestamp }}</td>
+                                        <td>{{ log.ip_address }}</td>
+                                    </tr>
+                                {% empty %}
+                                    <tr><td colspan="4">No audit logs.</td></tr>
+                                {% endfor %}
                             </tbody>
                         </table>
-                    {% else %}
-                        <p>No audit logs.</p>
-                    {% endif %}
-                </div>
+                    </div>
             </section>
 
             <!-- DEVICES -->


### PR DESCRIPTION
## Summary
- render audit logs in their own section
- close the upload section before starting the audit section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ccdb014d8832092b3d7d80ae3cf89