### PR TITLE
Fix document search tab selection

### DIFF
--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -1133,7 +1133,8 @@ def document_list(request):
     context = {
         'documents': documents,
         'query': query,
-        'show_documents': True
+        'show_documents': True,
+        'active_tab': 'documents'
     }
     
     if user.role == 'ADMIN':
@@ -1176,10 +1177,11 @@ def document_upload(request):
             return redirect('core:document_list')
     else:
         form = DocumentUploadForm()
-    
+
     return render(request, 'core/admin_dashboard.html', {
         'form': form,
-        'show_document_upload': True
+        'show_document_upload': True,
+        'active_tab': 'upload'
     })
 
 @login_required
@@ -1290,6 +1292,7 @@ def document_edit(request, doc_id):
         "edit_form": form,
         "edit_document": existing,
         "show_document_edit": True,
+        "active_tab": "documents",
     }
     if request.headers.get("x-requested-with") == "XMLHttpRequest":
         # Render only the modal for AJAX


### PR DESCRIPTION
## Summary
- ensure the dashboard opens the Documents tab after searching or editing
- keep the Upload tab active after uploading new documents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cda4e756083209dbfee29e8203864