### PR TITLE
Add session override button

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -658,17 +658,23 @@
                 <div class="card mt-24">
                     <h3>High‑risk Sessions</h3>
                     <table>
-                        <thead><tr><th>User</th><th>Risk Score</th><th>Reason</th><th>Last Seen</th></tr></thead>
+                        <thead><tr><th>User</th><th>Risk Score</th><th>Reason</th><th>Last Seen</th><th>Actions</th></tr></thead>
                         <tbody>
-                        {% for s in risky_sessions %}
+                        {% for s in high_risk_sessions %}
                             <tr>
                                 <td>{{ s.user.username }}</td>
                                 <td style="color:var(--danger)">{{ s.risk_score }}</td>
                                 <td>{{ s.reason }}</td>
                                 <td>{{ s.last_seen }}</td>
+                                <td>
+                                    <form method="post" action="{% url 'core:allow_high_risk_session' s.id %}" style="display:inline;">
+                                        {% csrf_token %}
+                                        <button class="btn btn-outline" type="submit">Allow Access</button>
+                                    </form>
+                                </td>
                             </tr>
                         {% empty %}
-                            <tr><td colspan="4">None 🎉</td></tr>
+                            <tr><td colspan="5">None 🎉</td></tr>
                         {% endfor %}
                         </tbody>
                     </table>
@@ -781,7 +787,7 @@
                 <div class="card">
                     <h2>Documents</h2>
                     <p class="mt-16" style="color:var(--text-dim); font-size:0.98rem;">Browse, search, download, and edit documents. Each document includes a title, department, and description for context.</p>
-                    <form method="get" action="" style="margin-bottom: 16px; display: flex; gap: 8px; align-items: center;">
+                    <form method="get" action="{% url 'core:document_list' %}" style="margin-bottom: 16px; display: flex; gap: 8px; align-items: center;">
                         <input type="text" name="q" value="{{ query|default:'' }}" placeholder="Search documents..." style="flex:1; padding:8px 10px; border-radius:6px; border:1px solid var(--border); background:var(--bg-soft); color:var(--text);">
                         <button class="btn btn-outline" type="submit">Search</button>
                     </form>
@@ -815,7 +821,7 @@
                     <table>
                         <thead><tr><th>User</th><th>Risk Score</th><th>Reason</th><th>Last Seen</th><th>Actions</th></tr></thead>
                         <tbody>
-                        {% for s in risky_sessions %}
+                        {% for s in high_risk_sessions %}
                             <tr>
                                 <td>{{ s.user.username }}</td>
                                 <td style="color:var(--danger)">{{ s.risk_score }}</td>

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -603,7 +603,7 @@
                 <div class="card">
                     <h2>Documents</h2>
                     <p class="mt-16" style="color:var(--text-dim); font-size:0.98rem;">Browse, search, and download documents. Each document includes a title, department, and description for context.</p>
-                    <form method="get" action="" style="margin-bottom: 16px; display: flex; gap: 8px; align-items: center;">
+                    <form method="get" action="{% url 'core:document_list' %}" style="margin-bottom: 16px; display: flex; gap: 8px; align-items: center;">
                         <input type="text" name="q" value="{{ query|default:'' }}" placeholder="Search documents..." style="flex:1; padding:8px 10px; border-radius:6px; border:1px solid var(--border); background:var(--bg-soft); color:var(--text);">
                         <button class="btn btn-outline" type="submit">Search</button>
                     </form>

--- a/WebAppIAM/core/urls.py
+++ b/WebAppIAM/core/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
     path('admin/users/activate/<int:user_id>/', views.activate_user, name='admin_activate_user'),
     path('admin/users/lock/<int:user_id>/', views.lock_user, name='admin_lock_user'),
     path('admin/users/unlock/<int:user_id>/', views.unlock_user, name='admin_unlock_user'),
+    path('admin/sessions/allow/<int:session_id>/', views.allow_high_risk_session, name='allow_high_risk_session'),
 
 
     # Profile Management


### PR DESCRIPTION
## Summary
- add an Allow Access button to the high‑risk sessions table at the top of the admin dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ce5ab2fc083209ac86f72355ed104