### PR TITLE
Render upload form on admin dashboard

### DIFF
--- a/WebAppIAM/core/views.py
+++ b/WebAppIAM/core/views.py
@@ -1135,6 +1135,8 @@ def admin_dashboard(request):
         'users': users,
         'pending_users': pending_users,
         'system_alerts': system_alerts,
+        'form': DocumentUploadForm(),
+        'show_document_upload': True,
         'active_tab': 'dashboard',
         'show_documents': True,
         'show_audit_logs': True,


### PR DESCRIPTION
## Summary
- expose DocumentUploadForm on admin dashboard

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688d09518fa08320a76e6075d9b8af7e