### PR TITLE
Add ML models dir setting

### DIFF
--- a/WebAppIAM/WebAppIAM/settings.py
+++ b/WebAppIAM/WebAppIAM/settings.py
@@ -209,3 +209,10 @@ CSRF_EXEMPT_PATHS = [
     '/core/webauthn/auth/',  # WebAuthn authentication endpoints
     '/core/health/'  # Health check endpoint
 ]
+
+# Machine Learning models directory
+# Allows override via environment variable for flexible deployments.
+ML_MODELS_DIR = os.environ.get(
+    "ML_MODELS_DIR",
+    os.path.join(BASE_DIR, "ml_pipeline", "models", "production")
+)


### PR DESCRIPTION
## Summary
- allow overriding ML model path in `settings.py`

## Testing
- `python WebAppIAM/manage.py test` *(0 tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_688d599a4204832087b4694db5174ad2