### PR TITLE
Implement document access levels

### DIFF
--- a/WebAppIAM/core/admin.py
+++ b/WebAppIAM/core/admin.py
@@ -61,8 +61,8 @@ class AuditLogAdmin(admin.ModelAdmin):
 
 @admin.register(Document)
 class DocumentAdmin(admin.ModelAdmin):
-    list_display = ('title', 'access_level', 'department', 'uploaded_by', 'created_at')
-    list_filter = ('access_level', 'department')
+    list_display = ('title', 'access_level', 'required_access_level', 'department', 'uploaded_by', 'created_at')
+    list_filter = ('access_level', 'required_access_level', 'department')
     search_fields = ('title', 'description', 'department')
 
 @admin.register(DocumentAccessLog)

--- a/WebAppIAM/core/forms.py
+++ b/WebAppIAM/core/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import PasswordChangeForm
-from .models import User, RiskPolicy, Document, UserProfile
+from .models import User, RiskPolicy, Document, UserProfile, ACCESS_LEVEL_CHOICES
 
 class RegistrationForm(forms.ModelForm):
     password1 = forms.CharField(
@@ -79,10 +79,10 @@ class DocumentUploadForm(forms.ModelForm):
         choices=UserProfile.DEPT_CHOICES,
         required=False
     )
-    
+
     class Meta:
         model = Document
-        fields = ['title', 'description', 'access_level', 'department']
+        fields = ['title', 'description', 'access_level', 'required_access_level', 'department']
         
     def save(self, commit=True):
         # Don't save the file directly, it will be encrypted in the view
@@ -100,7 +100,7 @@ class DocumentEditForm(forms.ModelForm):
 
     class Meta:
         model = Document
-        fields = ["title", "description", "access_level", "department"]
+        fields = ["title", "description", "access_level", "required_access_level", "department"]
 
     def save(self, commit=True):
         return super().save(commit=commit)
@@ -114,10 +114,14 @@ class ProfileCompletionForm(forms.ModelForm):
         max_length=30,
         widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Last Name'})
     )
-    
+    access_level = forms.ChoiceField(
+        choices=ACCESS_LEVEL_CHOICES,
+        label='Access Level'
+    )
+
     class Meta:
         model = UserProfile
-        fields = ['department', 'position', 'phone', 'profile_picture']
+        fields = ['department', 'position', 'access_level', 'phone', 'profile_picture']
         widgets = {
             'position': forms.TextInput(attrs={'class': 'form-control'}),
             'phone': forms.TextInput(attrs={'class': 'form-control', 'placeholder': '+1 (555) 555-5555'}),
@@ -135,10 +139,14 @@ class ProfileUpdateForm(forms.ModelForm):
     email = forms.EmailField(
         widget=forms.EmailInput(attrs={'class': 'form-control'})
     )
-    
+    access_level = forms.ChoiceField(
+        choices=ACCESS_LEVEL_CHOICES,
+        label='Access Level'
+    )
+
     class Meta:
         model = UserProfile
-        fields = ['department', 'position', 'phone', 'profile_picture',
+        fields = ['department', 'position', 'access_level', 'phone', 'profile_picture',
                   'show_risk_alerts', 'auto_logout', 'receive_email_alerts']
         widgets = {
             'position': forms.TextInput(attrs={'class': 'form-control'}),
@@ -164,6 +172,7 @@ class ProfileUpdateForm(forms.ModelForm):
         # Save profile fields
         profile.department = self.cleaned_data.get('department')
         profile.position = self.cleaned_data.get('position')
+        profile.access_level = self.cleaned_data.get('access_level')
         profile.phone = self.cleaned_data.get('phone')
         profile.profile_picture = self.cleaned_data.get('profile_picture')
         profile.show_risk_alerts = self.cleaned_data.get('show_risk_alerts')

--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -824,7 +824,7 @@
                     </form>
                     <table>
                         <thead>
-                        <tr><th>Title</th><th>Department</th><th>Description</th><th>Actions</th></tr>
+                        <tr><th>Title</th><th>Department</th><th>Description</th><th>Req. Level</th><th>Actions</th></tr>
                         </thead>
                         <tbody>
                         {% for doc in documents %}
@@ -832,6 +832,7 @@
                             <td>{{ doc.title }}</td>
                             <td>{{ doc.department }}</td>
                             <td>{{ doc.description|default:"—" }}</td>
+                            <td>{{ doc.get_required_access_level_display }}</td>
                             <td>
                                 <a class="btn btn-outline" href="{% url 'core:document_download' doc.id %}">Download</a>
                                 <a class="btn btn-outline" href="{% url 'core:document_edit' doc.id %}">Edit</a>
@@ -842,7 +843,7 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="4">No documents found.</td></tr>
+                        <tr><td colspan="5">No documents found.</td></tr>
                         {% endfor %}
                         </tbody>
                     </table>

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -614,7 +614,7 @@
                     </form>
                     <table>
                         <thead>
-                        <tr><th>Title</th><th>Department</th><th>Description</th><th>Actions</th></tr>
+                        <tr><th>Title</th><th>Department</th><th>Description</th><th>Req. Level</th><th>Actions</th></tr>
                         </thead>
                         <tbody>
                         {% for doc in documents %}
@@ -622,12 +622,13 @@
                             <td>{{ doc.title }}</td>
                             <td>{{ doc.department }}</td>
                             <td>{{ doc.description|default:"—" }}</td>
+                            <td>{{ doc.get_required_access_level_display }}</td>
                             <td>
                                 <a class="btn btn-outline" href="{% url 'core:document_download' doc.id %}">Download</a>
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="4">No documents found.</td></tr>
+                        <tr><td colspan="5">No documents found.</td></tr>
                         {% endfor %}
                         </tbody>
                     </table>

--- a/WebAppIAM/core/test_document_edit.py
+++ b/WebAppIAM/core/test_document_edit.py
@@ -36,6 +36,7 @@ class DocumentEditTests(TestCase):
                     'title': 'Doc',
                     'description': '',
                     'access_level': 'PRIVATE',
+                    'required_access_level': 1,
                     'department': '',
                     'file': new_file,
                 },


### PR DESCRIPTION
## Summary
- gate documents by user clearance level
- expose access level fields on document and profile forms
- display required access levels in dashboards and admin

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688de0dee9fc8320bce8d94d50aaee04