### PR TITLE
Refactor dashboard context and add PRG for settings

### DIFF
--- a/WebAppIAM/core/templates/core/admin_dashboard.html
+++ b/WebAppIAM/core/templates/core/admin_dashboard.html
@@ -1223,22 +1223,29 @@
         });
     });
 
-    // On load: show stored or hash target or dashboard
-    let initial = '{{ active_tab|default:"dashboard" }}';
-    const showUserManagement = JSON.parse("{{ show_user_management|yesno:'true,false'|lower }}".replace(/'/g, '"'));
-    const showProfileSettings = JSON.parse("{{ show_profile_settings|yesno:'true,false'|lower }}".replace(/'/g, '"'));
-    const showDocumentEdit = JSON.parse("{{ show_document_edit|yesno:'true,false'|lower }}".replace(/'/g, '"'));
-    if (showUserManagement) initial = 'users';
-    if (showProfileSettings) initial = 'profile';
-    if (showDocumentEdit) initial = 'documents';
-    try {
-        initial = localStorage.getItem('active-section') || initial;
-    } catch(e){}
-    if (location.hash) initial = location.hash.slice(1);
-    activate(initial);
-    // Setup password toggles immediately if we're on profile section
-    if (initial === 'profile') {
-        setupPasswordToggles();
+    const params = new URLSearchParams(location.search);
+    const tabParam = params.get('tab');
+    if (tabParam) {
+        activate(tabParam);
+        try { localStorage.setItem('active-section', tabParam); } catch (e) {}
+    } else {
+        // On load: show stored or hash target or dashboard
+        let initial = '{{ active_tab|default:"dashboard" }}';
+        const showUserManagement = JSON.parse("{{ show_user_management|yesno:'true,false'|lower }}".replace(/'/g, '"'));
+        const showProfileSettings = JSON.parse("{{ show_profile_settings|yesno:'true,false'|lower }}".replace(/'/g, '"'));
+        const showDocumentEdit = JSON.parse("{{ show_document_edit|yesno:'true,false'|lower }}".replace(/'/g, '"'));
+        if (showUserManagement) initial = 'users';
+        if (showProfileSettings) initial = 'profile';
+        if (showDocumentEdit) initial = 'documents';
+        try {
+            initial = localStorage.getItem('active-section') || initial;
+        } catch(e){}
+        if (location.hash) initial = location.hash.slice(1);
+        activate(initial);
+        // Setup password toggles immediately if we're on profile section
+        if (initial === 'profile') {
+            setupPasswordToggles();
+        }
     }
 
 })();

--- a/WebAppIAM/core/templates/core/staff_dashboard.html
+++ b/WebAppIAM/core/templates/core/staff_dashboard.html
@@ -882,16 +882,6 @@
             setupPasswordToggles();
         }
     }
-
-    let initial = '{{ active_tab|default:"dashboard" }}';
-    const showProfileSettings = JSON.parse("{{ show_profile_settings|yesno:'true,false'|lower }}".replace(/'/g, '"'));
-    if (showProfileSettings) initial = 'profile';
-    try {
-        initial = localStorage.getItem('staff-active-section') || initial;
-    } catch(e){}
-    if (location.hash) initial = location.hash.slice(1);
-    activate(initial);
-
     links.forEach(a => {
         a.addEventListener('click', e => {
             e.preventDefault();
@@ -899,10 +889,25 @@
             activate(section);
         });
     });
-    
-    // Setup password toggles immediately if we're on profile section
-    if (initial === 'profile') {
-        setupPasswordToggles();
+
+    const params = new URLSearchParams(location.search);
+    const tabParam = params.get('tab');
+    if (tabParam) {
+        activate(tabParam);
+        try { localStorage.setItem('staff-active-section', tabParam); } catch (e) {}
+    } else {
+        let initial = '{{ active_tab|default:"dashboard" }}';
+        const showProfileSettings = JSON.parse("{{ show_profile_settings|yesno:'true,false'|lower }}".replace(/'/g, '"'));
+        if (showProfileSettings) initial = 'profile';
+        try {
+            initial = localStorage.getItem('staff-active-section') || initial;
+        } catch(e){}
+        if (location.hash) initial = location.hash.slice(1);
+        activate(initial);
+        // Setup password toggles immediately if we're on profile section
+        if (initial === 'profile') {
+            setupPasswordToggles();
+        }
     }
 })();
 </script>


### PR DESCRIPTION
## Summary
- centralize dashboard data collection with `build_dashboard_context`
- ensure profile and password updates keep session and redirect with active tab
- redirect minor actions back to dashboard tab and honor `?tab=` in JS

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688dfd0a818083209ec0a92764b4a73b