### PR TITLE
Handle non-JSON responses in face verification flow

### DIFF
--- a/WebAppIAM/core/templates/core/enroll_biometrics.html
+++ b/WebAppIAM/core/templates/core/enroll_biometrics.html
@@ -517,10 +517,16 @@ qs('#btn-continue').addEventListener('click', async ()=>{
     fd.append('face_data', state.face.blob, 'face.jpg');
     const faceRes = await fetch(urls.faceUpload || '', {
       method:'POST', credentials:'same-origin',
-      headers:{ 'X-CSRFToken': CSRF },
+      headers:{
+        'X-CSRFToken': CSRF,
+        'X-Requested-With': 'XMLHttpRequest'
+      },
       body: fd
     });
-    const faceJson = await faceRes.json().catch(()=> ({}));
+    const ct = faceRes.headers.get('content-type') || '';
+    const faceJson = ct.includes('application/json')
+      ? await faceRes.json().catch(() => ({}))
+      : {};
     if(!faceRes.ok || (faceJson.status && faceJson.status==='error')){
       throw new Error(faceJson.message || `Face upload failed (HTTP ${faceRes.status})`);
     }

--- a/WebAppIAM/core/templates/core/login.html
+++ b/WebAppIAM/core/templates/core/login.html
@@ -580,17 +580,24 @@
         fd.append('face_data', blob, 'face.jpg');
         
         const res = await fetch(ENDPOINTS.faceUpload, {
-          method: 'POST', 
-          credentials: 'same-origin', 
-          headers: { 'X-CSRFToken': getCSRF() },
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRFToken': getCSRF(),
+            'X-Requested-With': 'XMLHttpRequest'
+          },
           body: fd
         });
-        
-        const data = await res.json();
+
+        const ct = res.headers.get('content-type') || '';
+        const data = ct.includes('application/json')
+          ? await res.json()
+          : {};
         if(data.status === 'ok' || data.status === 'success'){
           window.location.href = data.next || '/';
         } else {
-          throw new Error(data.message || 'Verification failed');
+          const msg = data.message || (res.ok ? 'Verification failed' : `HTTP ${res.status}`);
+          throw new Error(msg);
         }
       } catch(err) {
         console.error('Face Verification Error:', err);


### PR DESCRIPTION
## Summary
- Ensure face verification and enrollment uploads send `X-Requested-With` header and validate JSON responses.
- Guard against unexpected response formats during face verification, providing clearer error messages.

## Testing
- `python manage.py test` *(fails: test_login_get_sets_csrf_in_session, test_register_biometrics_face_error)*

------
https://chatgpt.com/codex/tasks/task_e_688e98f9ef4483208da451f53bfb038f